### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "express": "^5.1.0",
     "mongodb": "^6.10.0",
     "socket.io": "^4.8.1",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/1](https://github.com/richardthorek/Station-Manager/security/code-scanning/1)

To resolve this security concern, the fix is to add an HTTP rate-limiting middleware to the Express app using a standard package like `express-rate-limit`. The most robust and least disruptive way is to apply a reasonable rate limiter *globally* or to the specific SPA fallback route (`app.get(/^\/(?!api).*/...)`). 

- **General steps:** 
  - Install and import `express-rate-limit`.
  - Define a rate limiter (e.g., 100 requests per 15 minutes per IP address).
  - Apply this limiter either globally (`app.use(limiter)`) or specifically to the SPA fallback route.
- **Where to change:** Only in `backend/src/index.ts`, near the top after imports and before route registration, plus in the SPA fallback route.
- **Implementation:** Import `express-rate-limit`, define the limiter, and use it with the appropriate route.
- **Notes:** This change avoids interfering with API or Socket routes, and focuses solely on the route in question for minimum disruption.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
