### PR TITLE
Potential fix for code scanning alert no. 10: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoTruckChecksDatabase.ts
+++ b/backend/src/services/mongoTruckChecksDatabase.ts
@@ -390,7 +390,7 @@ class MongoTruckChecksDatabase {
       throw new Error('Database not connected');
     }
     
-    const checkRun = await this.checkRunsCollection.findOne({ id: runId });
+    const checkRun = await this.checkRunsCollection.findOne({ id: { $eq: runId } });
     if (!checkRun) {
       throw new Error('Check run not found');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/10](https://github.com/richardthorek/Station-Manager/security/code-scanning/10)

We need to ensure that user-supplied input used in MongoDB queries is interpreted as a literal value and not as a query operator/object. The recommended fix is to use the `$eq` operator so that MongoDB always treats the user input as a strict equality comparison rather than a possibly malicious object. Specifically, in `createCheckResult`, the query should be changed from `{ id: runId }` to `{ id: { $eq: runId } }` in the call to `findOne`. This fix is limited to a single line in `backend/src/services/mongoTruckChecksDatabase.ts`. No new imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
