### PR TITLE
Potential fix for code scanning alert no. 9: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoTruckChecksDatabase.ts
+++ b/backend/src/services/mongoTruckChecksDatabase.ts
@@ -329,7 +329,7 @@ class MongoTruckChecksDatabase {
   async getCheckRunsByAppliance(applianceId: string): Promise<CheckRun[]> {
     if (!this.checkRunsCollection) throw new Error('Database not connected');
     return await this.checkRunsCollection
-      .find({ applianceId })
+      .find({ applianceId: { $eq: applianceId } })
       .sort({ startTime: -1 })
       .toArray();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/9](https://github.com/richardthorek/Station-Manager/security/code-scanning/9)

To fix the vulnerability, we should ensure that the user-supplied value, `applianceId`, is interpreted by MongoDB only as a literal value and not as a query object or operator. The simplest robust approach is to use the `$eq` operator in the filter, i.e. `{ applianceId: { $eq: applianceId } }`, which ensures that no matter what is provided, MongoDB treats it as a literal match. Alternatively, we could validate at runtime that `applianceId` is a string, but that is more error-prone and less robust than using `$eq`. Therefore, edit `getCheckRunsByAppliance` in `mongoTruckChecksDatabase.ts` (line 332), replacing `.find({ applianceId })` with `.find({ applianceId: { $eq: applianceId } })`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
