### PR TITLE
Potential fix for code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoDatabase.ts
+++ b/backend/src/services/mongoDatabase.ts
@@ -542,7 +542,10 @@ class MongoDBService {
   async getMemberParticipantInEvent(eventId: string, memberId: string): Promise<EventParticipant | null> {
     if (!this.eventParticipantsCollection) throw new Error('Database not connected');
     
-    return await this.eventParticipantsCollection.findOne({ eventId, memberId });
+    return await this.eventParticipantsCollection.findOne({
+      eventId: { $eq: eventId },
+      memberId: { $eq: memberId }
+    });
   }
 
   async getAllActiveParticipants(): Promise<EventParticipant[]> {


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/7](https://github.com/richardthorek/Station-Manager/security/code-scanning/7)

To fix this NoSQL injection vulnerability, we must ensure that both `eventId` and particularly `memberId` are treated as literal values (not operator objects) when constructing the query filter. The primary and most idiomatic way to do this in MongoDB is to use the `$eq` query operator, which forces the value to be interpreted literally. Alternatively, we can check that `memberId` is a string (and optionally, in the correct format), and reject the request if not.

The best, least-disruptive fix is to change the line:

```ts
return await this.eventParticipantsCollection.findOne({ eventId, memberId });
```

to

```ts
return await this.eventParticipantsCollection.findOne({ eventId: { $eq: eventId }, memberId: { $eq: memberId } });
```

This ensures both values are used as literals. Making both fields safe is best-practice even if `eventId` is derived from a path parameter and may not be directly user-controlled.

No additional imports or definitions are needed; only this line needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
