### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoDatabase.ts
+++ b/backend/src/services/mongoDatabase.ts
@@ -203,7 +203,7 @@ class MongoDBService {
 
   async getActivityById(id: string): Promise<Activity | null> {
     if (!this.activitiesCollection) throw new Error('Database not connected');
-    return await this.activitiesCollection.findOne({ id });
+    return await this.activitiesCollection.findOne({ id: { $eq: id } });
   }
 
   async createActivity(name: string, createdBy?: string): Promise<Activity> {


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/3](https://github.com/richardthorek/Station-Manager/security/code-scanning/3)

The best way to fix this issue is to ensure that the `id` field in the MongoDB query is always treated as a literal rather than a query object. Among possible approaches, using the `$eq` operator in the query ensures that any malicious input will be interpreted as a simple value, not as a query operator. Alternatively, explicit type validation can be used.

The single best fix in this context is to change line 206 from:
```ts
return await this.activitiesCollection.findOne({ id });
```
to:
```ts
return await this.activitiesCollection.findOne({ id: { $eq: id } });
```
This change should be made in the MongoDBService `getActivityById` method in file `backend/src/services/mongoDatabase.ts`. No other changes are required, and no imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
