### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoDatabase.ts
+++ b/backend/src/services/mongoDatabase.ts
@@ -146,7 +146,7 @@ class MongoDBService {
 
   async getMemberById(id: string): Promise<Member | null> {
     if (!this.membersCollection) throw new Error('Database not connected');
-    return await this.membersCollection.findOne({ id });
+    return await this.membersCollection.findOne({ id: { $eq: id } });
   }
 
   async getMemberByQRCode(qrCode: string): Promise<Member | null> {


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/2](https://github.com/richardthorek/Station-Manager/security/code-scanning/2)

The best way to fix this issue is to ensure that the untrusted input (the member ID) is interpreted by MongoDB as a literal value and not as a query object. This can be achieved either by using MongoDB's `$eq` operator in the query or by validating the value is a string before using it. The recommended fix is to use the `$eq` operator for the query, which ensures that the value is treated as a literal and not as an object containing MongoDB operators.  
Specifically, in `getMemberById` within `mongoDatabase.ts`, change the line:
```ts
return await this.membersCollection.findOne({ id });
```
to:
```ts
return await this.membersCollection.findOne({ id: { $eq: id } });
```
This change ensures that even if the user supplies an object, it will be interpreted as a literal value, fixing the NoSQL injection risk. No additional imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
