### PR TITLE
Potential fix for code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoDatabase.ts
+++ b/backend/src/services/mongoDatabase.ts
@@ -449,7 +449,7 @@ class MongoDBService {
       throw new Error('Event not found');
     }
 
-    const member = await this.membersCollection.findOne({ id: memberId });
+    const member = await this.membersCollection.findOne({ id: { $eq: memberId } });
     if (!member) {
       throw new Error('Member not found');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/6](https://github.com/richardthorek/Station-Manager/security/code-scanning/6)

To fix this NoSQL injection vulnerability in `addEventParticipant`, we need to ensure that untrusted user input for `memberId` is treated *only* as a literal value, not as a query object. This can be achieved in either of two safe ways:

1. Add an explicit type check for `memberId` to ensure it's a string before proceeding with the query.
2. Use the MongoDB `$eq` operator to force strict value matching, making it impossible for input-provided query operators to be evaluated.

The best fix here, as per current best practice and the recommendation in the background information, is to use the `$eq` operator: this is concise, avoids extra boilerplate, and is robust. This means changing:
```ts
const member = await this.membersCollection.findOne({ id: memberId });
```
to:
```ts
const member = await this.membersCollection.findOne({ id: { $eq: memberId } });
```
This ensures that the query always treats `memberId` as a literal value.

Only `backend/src/services/mongoDatabase.ts` needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
