### PR TITLE
Potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/backend/src/services/mongoDatabase.ts
+++ b/backend/src/services/mongoDatabase.ts
@@ -285,7 +285,7 @@ class MongoDBService {
 
   async getCheckInByMember(memberId: string): Promise<CheckIn | null> {
     if (!this.checkInsCollection) throw new Error('Database not connected');
-    return await this.checkInsCollection.findOne({ memberId, isActive: true });
+    return await this.checkInsCollection.findOne({ memberId: { $eq: memberId }, isActive: true });
   }
 
   async createCheckIn(


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/Station-Manager/security/code-scanning/4](https://github.com/richardthorek/Station-Manager/security/code-scanning/4)

To fix the vulnerability, ensure that untrusted data (`memberId`) is interpreted strictly as a literal value in the MongoDB query.  
The best fix is to use MongoDB's `$eq` operator in the query, guaranteeing that `memberId` will only match if it's exactly equal to the literal user-provided value.  
Alternatively or additionally, type-check that `memberId` is a string (since in this code, it seems to represent a UUID string for members) before performing the query, returning a bad request error if not.  
The primary change is in `backend/src/services/mongoDatabase.ts`: inside the `getCheckInByMember` method, replace `{ memberId, isActive: true }` with `{ memberId: { $eq: memberId }, isActive: true }`.

No changes to imports are necessary, as `$eq` is a built-in MongoDB operator and does not require explicit import.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
