### PR TITLE
Design docs: AI maintenance agent + SaaS commercialization (future release)

### DIFF
--- a/docs/AI_MAINTENANCE_AGENT_DESIGN.md
+++ b/docs/AI_MAINTENANCE_AGENT_DESIGN.md
@@ -1,0 +1,330 @@
+# Design: AI Voice (and Vision) Truck-Maintenance Agent
+
+**Status:** Draft / future release (design only — not yet implemented)
+**Author:** Design spike, June 2026
+**Related:** `docs/MASTER_PLAN.md`, `docs/AS_BUILT.md` (Truck Check), v1.1 cross-brigade schema
+
+---
+
+## 1. Vision
+
+A hands-free assistant that walks a volunteer through a truck check by voice, and
+eventually by camera. The member wears headphones (or uses a phone on a lanyard),
+says *"I'm starting the Cat 1 tanker,"* then narrates as they work:
+
+> **Member:** "Starting the Cat 1 tanker."
+> **Agent:** "Righto — Cat 1 Tanker 7. Last checked 9 days ago, two open issues from
+> then: the driver-side locker latch and the secondary pump prime. Want to start at
+> the cab or the pump panel?"
+> **Member:** "Cab. Oil's good, coolant's good, lights all working."
+> **Agent:** "Got it — engine oil OK, coolant OK, lights OK. While you're in the cab:
+> radio check and the BA seat brackets? Those two are still on the Cat 1 list."
+> **Member:** "Radio's fine. One BA bracket is cracked."
+> **Agent:** "Logging a **issue** on BA seat bracket — want a photo? I'll flag it for
+> the captain. Moving to the pump panel next…"
+
+The agent:
+- knows **this specific truck** (its layout, equipment, age, and known quirks),
+- prompts **follow-ups in the same physical area** ("while you're in the cab…"),
+- produces a **formal, auditable check record** *and* keeps the **full transcript**,
+- adapts tone/among items by **brigade conventions** and **vehicle age/variant**.
+
+This builds directly on the v1.1 truck-check schema (canonical `vehicleType`,
+`itemCode`, `section`) — the agent is a new **input method**, not a new source of truth.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Hands-free voice check that yields the same `CheckRun`/`CheckResult` records as the
+  manual workflow (compliance + reporting unchanged) **plus** a narrative transcript.
+- Per-truck uniqueness: every appliance can have its own zones, equipment, and quirks
+  while still mapping to standard codes for cross-brigade analytics.
+- Follow-up prompting scoped to the current physical **zone**.
+- Brigade- and age-aware nuance via a **hybrid** of structured per-truck data + LLM
+  inference (not hand-authored decision trees).
+
+**Non-goals (initially)**
+- Offline / on-device speech (Phase 3) — **cloud-only to start** per product decision.
+- Native apps — web PWA first.
+- Vision — schema is future-proofed now, feature comes in Phase 4.
+- Replacing the manual workflow — voice is additive; manual remains.
+
+## 3. Phased delivery
+
+| Phase | Scope | Depends on |
+|---|---|---|
+| **0 — done (v1.1)** | Canonical `vehicleType`/`itemCode`/`section`, structured CheckRun/CheckResult | shipped |
+| **1 — Truck model** | New schema: zones, equipment, vehicle attributes, quirks; admin UI to author them. **No AI.** Independently useful (richer manual checks, sectioned by real zones). | Phase 0 |
+| **2 — Voice agent (cloud)** | PWA voice mode → live agent → CheckRun + transcript; hybrid knowledge; readback/confirmation; issue flagging | Phase 1 |
+| **3 — Offline + native** | On-device/queued speech, native wrappers | Phase 2 stable |
+| **4 — Vision** | Camera frames to a vision model; "show me the gauge"; visual diff vs reference photos | Phase 2 |
+
+Phase 1 is the foundation and is **worth shipping on its own** even before any AI.
+
+## 4. Data schema changes
+
+Design principles (consistent with the existing codebase):
+- **Additive & backward-compatible** — every new field is optional; existing
+  appliances/templates/runs/results keep working untouched.
+- **Two DB twins** — each new entity is implemented in **both** `database.ts`
+  (in-memory) and `tableStorageDatabase.ts` (Table Storage), behind the existing
+  factory pattern. Shared types in `backend/src/types/index.ts` and mirrored in
+  `frontend/src/types/index.ts`.
+- **Standardisation *and* uniqueness** — canonical `*Code` slugs (cross-brigade
+  analytics) live alongside per-appliance rows (uniqueness). A truck is never forced
+  into a shared template; it owns its zones/equipment.
+- **Denormalise on write** — like `CheckResult.itemCode`/`section` today, new results
+  copy `zoneId`/codes at check time so history stays comparable after later edits.
+
+### 4.1 New entity — `ApplianceZone` (per-truck spatial model)
+
+The core primitive for "every truck is unique" and "prompt in the same area." Replaces
+the flat `ChecklistItem.section` string with a real, per-appliance, ordered, optionally
+hierarchical set of physical areas.
+
+```typescript
+export interface ApplianceZone {
+  id: string;
+  applianceId: string;          // belongs to exactly ONE truck → uniqueness
+  stationId?: string;
+  name: string;                 // "Pump Panel", "Driver-side Locker 1", "Cab"
+  zoneCode?: string;            // canonical slug for cross-brigade analytics, e.g. 'pump-panel'
+  parentZoneId?: string;        // optional hierarchy (Locker 1 under Driver-side lockers)
+  side?: 'driver' | 'passenger' | 'front' | 'rear' | 'top' | 'interior' | 'na';
+  order: number;                // natural walk-around order (drives agent flow)
+  description?: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+```
+
+A **standard starter taxonomy** of `zoneCode`s per `vehicleType` (a code-level
+vocabulary, like the existing `checklistVocabulary.ts`) seeds a new truck's zones;
+the brigade then edits/adds/removes to match the actual vehicle.
+
+### 4.2 New entity — `ApplianceEquipment` (per-truck inventory)
+
+Captures equipment differences between trucks so the agent knows what's actually on
+*this* vehicle (and where).
+
+```typescript
+export interface ApplianceEquipment {
+  id: string;
+  applianceId: string;
+  stationId?: string;
+  name: string;                 // "Holmatro spreader", "BA set #2", "Akron branch"
+  equipmentCode?: string;       // canonical slug for analytics
+  zoneId?: string;              // where it lives on the truck
+  serialNumber?: string;
+  notes?: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+```
+
+### 4.3 Extend `Appliance` (vehicle attributes + quirks → age/nuance)
+
+```typescript
+export interface Appliance {
+  // ...existing: id, name, description?, photoUrl?, stationId?, vehicleType?
+  year?: number;                // build year → age-based nuance for the agent
+  make?: string;
+  model?: string;
+  variant?: string;             // e.g. 'Isuzu FTS', 'BTM body'
+  registration?: string;
+  inServiceDate?: string;
+  quirksNotes?: string;         // free-text brigade knowledge: "hatch sticks in cold",
+                                // "secondary pump primes slowly" — fed to the LLM
+}
+```
+
+### 4.4 Extend `ChecklistItem`
+
+```typescript
+export interface ChecklistItem {
+  // ...existing: id, name, description?, order, referencePhotoUrl?, itemCode?, section?
+  zoneId?: string;              // link to ApplianceZone (richer than 'section')
+  equipmentId?: string;         // item checks a specific piece of equipment
+  expectedResponseType?: 'ok-issue' | 'numeric' | 'level' | 'text';
+  unit?: string;                // for numeric, e.g. 'psi', 'L', '%'
+  promptHint?: string;          // optional phrasing nudge for the agent
+}
+```
+`section` is retained for backward compatibility; when a `zoneId` is present the zone
+name is the source of truth and `section` can be derived.
+
+### 4.5 Extend `CheckRun` (link the session + input source)
+
+```typescript
+export interface CheckRun {
+  // ...existing fields
+  source?: 'manual' | 'voice' | 'voice-vision';   // default 'manual'
+  agentSessionId?: string;                         // → AgentSession
+}
+```
+
+### 4.6 Extend `CheckResult` (voice provenance + values + review)
+
+```typescript
+export interface CheckResult {
+  // ...existing: id, runId, itemId, itemName, status, comment?, photoUrl?,
+  //              completedBy?, stationId?, itemCode?, section?
+  zoneId?: string;              // denormalised at check time (like itemCode/section)
+  source?: 'manual' | 'voice' | 'voice-vision';
+  capturedValue?: string;       // spoken value, e.g. "32 psi", "3/4 tank"
+  confidence?: number;          // 0–1 agent confidence in the mapping
+  needsReview?: boolean;        // low confidence / ambiguous → human sign-off
+}
+```
+
+### 4.7 New entities — `AgentSession` + `AgentTurn` (the "both" answer)
+
+The formal `CheckRun` stays the compliance record; the session captures the full
+narrative transcript and provenance as supporting evidence.
+
+```typescript
+export interface AgentSession {
+  id: string;
+  runId?: string;               // linked CheckRun (the formal output)
+  applianceId: string;
+  stationId?: string;
+  startedBy: string;
+  startTime: string;
+  endTime?: string;
+  status: 'active' | 'completed' | 'abandoned';
+  modality: 'voice' | 'voice-vision';
+  language?: string;            // e.g. 'en-AU'
+  summary?: string;             // LLM end-of-session summary
+  models?: string;              // provenance, e.g. "claude-opus-4-8; azure-speech"
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface AgentTurn {
+  id: string;
+  sessionId: string;
+  role: 'user' | 'agent' | 'system';
+  text: string;                 // transcribed speech or agent utterance
+  timestamp: string;
+  audioRef?: string;            // optional Blob ref IF audio retention is enabled (privacy-gated)
+  imageRef?: string;            // Phase 4: captured camera frame (Blob ref)
+  linkedItemId?: string;        // the checklist item this turn resolved
+  linkedResultId?: string;      // the CheckResult it produced
+  confidence?: number;
+}
+```
+
+**Storage strategy (Table Storage twin):**
+- `ApplianceZones`, `ApplianceEquipment`: PartitionKey = `applianceId` (or `stationId`),
+  RowKey = `id`.
+- `AgentSessions`: PartitionKey = `applianceId` (or `stationId`), RowKey = `id`.
+- `AgentTurns`: PartitionKey = `sessionId`, RowKey = `timestamp`-ordered id — keeps a
+  session's transcript in one partition for cheap sequential reads.
+- Large/binary artifacts (audio frames, images) go in **Blob Storage** via the existing
+  `azureStorage.ts` (new containers `agent-audio`, `agent-frames`), referenced by
+  `audioRef`/`imageRef`. Transcript **text** stays in Table Storage.
+
+### 4.8 Standardisation vs uniqueness (how both hold)
+
+| Concern | Standard (cross-brigade) | Unique (per-truck) |
+|---|---|---|
+| Vehicle class | `Appliance.vehicleType` slug | `make/model/variant/year` |
+| Areas | `ApplianceZone.zoneCode` slug | the actual `ApplianceZone` rows per truck |
+| Items | `ChecklistItem.itemCode` slug | per-appliance template + `zoneId` |
+| Equipment | `ApplianceEquipment.equipmentCode` | per-appliance equipment rows |
+| Quirks | — | `Appliance.quirksNotes`, equipment `notes` |
+
+Reporting/analytics join on the canonical `*Code`s; the agent and the check operate on
+the per-truck rows. No truck is forced to share another's layout.
+
+## 5. Agent runtime (Phase 2, cloud-only)
+
+```
+Headphones ⇄ PWA (mic capture, audio playback)
+                 │  audio stream (WebSocket)
+                 ▼
+        Backend "agent gateway"
+        ├─ STT (streaming)            ─┐
+        ├─ Agent orchestrator (LLM)    │  provider-agnostic adapters
+        └─ TTS (streaming)            ─┘
+                 │  tool calls
+                 ▼
+        Truck-check services (existing factories)
+        get_appliance_context · record_result · flag_issue ·
+        next_unchecked_in_zone · complete_run
+                 │
+                 ▼
+        CheckRun + CheckResult (formal)  +  AgentSession/AgentTurn (transcript)
+```
+
+**Orchestration via tool use.** The LLM drives the dialogue and calls tools to read
+context and persist structured results — it never writes the DB directly:
+- `get_appliance_context(applianceId)` → zones (ordered), items grouped by zone,
+  equipment, vehicle attributes, `quirksNotes`, last check + open issues.
+- `record_result(itemId, status, capturedValue?, comment?, confidence)` → `CheckResult`
+  with `source:'voice'`.
+- `flag_issue(itemId, detail, wantsPhoto)` → issue result + optional photo capture.
+- `next_unchecked_in_zone(zoneId)` / `open_issues(applianceId)` → drive "same area"
+  follow-ups.
+- `complete_run()` → close `CheckRun`, write `AgentSession.summary`.
+
+**Hybrid knowledge (the nuance).** The prompt is grounded in the truck's structured
+data (zones/equipment/attributes/quirks/history); the LLM *infers* natural follow-ups
+and age/variant adjustments from it (e.g., older `year` + a `quirksNotes` hint →
+"check the secondary prime, it's slow on this one"). Brigades author **facts**, not
+dialogue trees.
+
+**Compliance safety:**
+- **Read-back & confirm** each recorded result; ambiguous/low-confidence →
+  `needsReview:true` for human sign-off in the admin dashboard.
+- The formal `CheckRun` is the audit record; the transcript is supporting evidence with
+  model provenance (`AgentSession.models`).
+- Corrections are first-class ("no, that was the other tank") → the agent revises the
+  `CheckResult` and logs the correction as a new turn.
+
+**Suggested stack (provider-agnostic behind adapters):** Claude (Anthropic API) for the
+agent reasoning/tool-use; Azure AI Speech for streaming STT/TTS (good en-AU support,
+fits the Azure footprint). Both sit behind interfaces so either can be swapped, and so a
+single realtime voice model could replace the STT+TTS pair later.
+
+## 6. Vision (Phase 4) — already accommodated
+
+- `AgentSession.modality:'voice-vision'`, `AgentTurn.imageRef` (Blob frame).
+- The agent can request a frame ("show me the gauge"), send it to a vision-capable model,
+  and **diff against `ChecklistItem.referencePhotoUrl`** (already in the schema).
+- `ApplianceZone` can later gain optional position metadata for AR overlays without a
+  breaking change.
+
+## 7. Privacy, compliance, cost
+
+- **Audio retention OFF by default.** Store transcript **text** + structured results;
+  raw audio only if a brigade opts in (consent + retention policy), in Blob with a TTL.
+- **Data minimisation / audit:** provenance, confidence, `needsReview`, and correction
+  turns give a defensible trail. Aligns with the existing `EventAuditLog` philosophy.
+- **Cost:** per-session LLM tokens + speech minutes. Sessions are short and bursty —
+  a strong fit for the **scale-to-zero Container Apps** option in `infra/` (pay per
+  active session, ~$0 when idle). Add per-brigade usage caps.
+
+## 8. Open questions (for build time, not blocking design)
+
+- Streaming transport: extend the existing Socket.io channel vs a dedicated audio WS.
+- STT/TTS provider final pick + en-AU accuracy on fire-service jargon (custom vocab).
+- Barge-in / interruption handling and noise robustness in a loud shed.
+- How aggressively to auto-complete unspoken items (reuse the "mark remaining as OK"
+  pattern, but voice-confirmed).
+- Exact canonical zone/equipment vocabularies per `vehicleType` (RFS SMEs to seed).
+
+## 9. Summary of schema deltas
+
+- **New:** `ApplianceZone`, `ApplianceEquipment`, `AgentSession`, `AgentTurn`
+  (both DB twins + shared types + factories; new Blob containers for audio/frames).
+- **Extended (all optional):** `Appliance` (+year/make/model/variant/registration/
+  inServiceDate/quirksNotes), `ChecklistItem` (+zoneId/equipmentId/expectedResponseType/
+  unit/promptHint), `CheckRun` (+source/agentSessionId), `CheckResult` (+zoneId/source/
+  capturedValue/confidence/needsReview).
+- **Vocabulary (code-level, not DB):** canonical `zoneCode`/`equipmentCode` starter
+  taxonomies per `vehicleType`, mirroring `checklistVocabulary.ts`.
+
+Nothing here breaks existing data: a truck with no zones/equipment/attributes behaves
+exactly as today, and the voice layer is purely additive.

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1584,6 +1584,43 @@ the design doc for full detail.
 
 ---
 
+#### Feature: Self-Service Sign-up, Multi-Tenant Billing & Commercialization
+**Status**: 📐 **DESIGN / FUTURE RELEASE** (design doc only — not implemented)
+**Design**: `docs/SAAS_COMMERCIALIZATION_DESIGN.md`
+
+**Objective**: Turn Station Manager into a self-service SaaS — a brigade signs up online,
+picks a plan, pays via **Stripe**, enrols device-type accounts (kiosk/tablet/phone/
+wearable), and activates member accounts. The AI maintenance agent is sold as a paid
+add-on.
+
+**Tenancy**: introduce a top-level **`Organization`** (billing tenant) above the existing
+`brigadeId`/`stationId` model; formalise `BrigadeAccessToken` into first-class `Device`
+accounts; add optional member activation (login). `organizationId` becomes the outer
+isolation boundary; existing data migrates under one default org (mirrors `default-station`).
+
+**Billing (Stripe — endorsed)**: Checkout + Billing + Customer Portal + signature-verified
+webhooks → entitlement sync; Stripe Tax for GST; metered usage for AI overage; Invoicing
+for grant-funded brigades. We store only Stripe IDs (PCI SAQ-A).
+
+**Pricing assessment & recommendation**: Basic infra cost per brigade is < A$1/mo, so
+**Basic at A$10/mo is very healthy**. AI cost is usage-driven (~A$0.60/voice session;
+~A$5–7/mo light, A$18–36/mo heavy), so a **flat A$15 AI tier does not safely cover it**.
+Recommendation: **Community (free)** funnel tier, **Basic A$10/mo**, **AI (Pro) A$19/mo**
+with a fair-use allowance (~25 sessions) + ~A$0.60/session overage (or honour A$15 with a
+tighter cap). Push **annual billing (2 months free)** to cut Stripe fee drag and suit
+grant/council budgets.
+
+**Schema deltas (summary)**: new `Organization`, `Device`, `UsageRecord`, `BillingEvent`;
+optional extensions to `Station` (+organizationId), `AdminUser` (+organizationId, owner
+role), `Member` (+email/authStatus/userId/invitedAt). Plans = code-level catalog mapped to
+Stripe Price IDs. Phased A (tenant model) → B (billing+signup) → C (devices+members) → D
+(AI metering + storefront). Phase D depends on the AI agent (Phase 2 of that design).
+
+**Priority**: P2 (strategic / commercialization) · **Labels**: `feature`, `billing`,
+`multi-tenant`, `stripe`, `phase-4`
+
+---
+
 
 #### Issue #18: Notification System (Email/SMS)
 **GitHub Issue**: #120 (created 2026-01-04T09:26:06Z)

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1550,6 +1550,40 @@ Priority: **MEDIUM** - Long-term enhancements
 
 ---
 
+#### Feature: AI Voice (and Vision) Truck-Maintenance Agent
+**Status**: 📐 **DESIGN / FUTURE RELEASE** (design doc only — not implemented)
+**Design**: `docs/AI_MAINTENANCE_AGENT_DESIGN.md`
+
+**Objective**: A hands-free assistant that walks a volunteer through a truck check by
+voice ("I'm starting the Cat 1 tanker…"), prompting follow-ups in the same physical
+area of the truck, tuned to each brigade's layout and each vehicle's age/quirks. Camera
+("vision") is a later phase.
+
+**Product decisions captured (June 2026)**:
+- Connectivity: **cloud-only first**; offline/native later.
+- Output: produce the **same auditable `CheckRun`/`CheckResult`** records **and** keep a
+  full narrative transcript (`AgentSession`/`AgentTurn`).
+- Layout: **per-truck zones/compartments** seeded from a standard starter taxonomy
+  (every truck unique; codes give cross-brigade comparability).
+- Nuance: **hybrid** — brigades author structured facts (zones, equipment, vehicle
+  year/variant, quirks), the LLM infers natural follow-ups and age adjustments.
+
+**Phasing**: Phase 1 = truck-model schema + admin UI (no AI, independently useful);
+Phase 2 = cloud voice agent (PWA) → CheckRun + transcript; Phase 3 = offline/native;
+Phase 4 = vision. Schema is designed to be additive and backward-compatible across both
+DB twins. Real-time/voice sessions are a natural fit for the scale-to-zero Container Apps
+hosting option (see `infra/`).
+
+**Schema deltas (summary)**: new `ApplianceZone`, `ApplianceEquipment`, `AgentSession`,
+`AgentTurn`; optional extensions to `Appliance` (year/make/model/variant/quirksNotes),
+`ChecklistItem` (zoneId/equipmentId/expectedResponseType/unit), `CheckRun` (source/
+agentSessionId), `CheckResult` (zoneId/source/capturedValue/confidence/needsReview). See
+the design doc for full detail.
+
+**Priority**: P2 (strategic) · **Labels**: `feature`, `ai`, `truck-check`, `phase-4`
+
+---
+
 
 #### Issue #18: Notification System (Email/SMS)
 **GitHub Issue**: #120 (created 2026-01-04T09:26:06Z)

--- a/docs/SAAS_COMMERCIALIZATION_DESIGN.md
+++ b/docs/SAAS_COMMERCIALIZATION_DESIGN.md
@@ -1,0 +1,233 @@
+# Design: Self-Service Sign-up, Multi-Tenant Billing & Commercialization
+
+**Status:** Draft / future release (design only — not implemented)
+**Author:** Design spike, June 2026
+**Related:** `docs/AI_MAINTENANCE_AGENT_DESIGN.md`, `docs/AS_BUILT.md` (Multi-Station,
+Auth), `docs/MASTER_PLAN.md`
+
+---
+
+## 1. Goal
+
+Turn Station Manager from a single hand-provisioned deployment into a **self-service
+SaaS**: a brigade signs up online, picks a plan, pays (Stripe), enrols their devices,
+and activates their members — with the **AI maintenance agent** sold as a paid add-on.
+Pricing must be **reasonable for volunteer brigades** while safely covering costs
+(especially AI).
+
+## 2. How this maps onto what already exists
+
+| SaaS concept | Today | Change needed |
+|---|---|---|
+| Billing tenant | — (none) | **New `Organization`** entity (owns the Stripe relationship) |
+| Brigade / Station | `Station` with `brigadeId`, `brigadeName`, `hierarchy` | add `organizationId` link |
+| Device / kiosk | `BrigadeAccessToken` (UUID, → brigade+station) | **formalise into `Device` accounts** with a type |
+| Admin login | `AdminUser` (JWT, global) | scope to an `Organization`; add an **owner** role |
+| Member | `Member` (record, no login) | optional **member activation** (email invite → login) |
+| Data isolation | by `stationId` | add `organizationId` as the outer tenant boundary |
+
+The tenancy hierarchy becomes:
+
+```
+Organization (billing tenant, Stripe customer)
+ └─ Brigade(s) / Station(s)        (existing brigadeId/stationId)
+     ├─ Device accounts            (kiosk / tablet / phone / wearable)
+     └─ Members                    (optionally activated to a login)
+```
+
+A single-station brigade is just an Organization with one Station — the common case.
+
+## 3. Self-service onboarding flow
+
+1. **Sign up** (email + org name) → create `Organization` in `trialing`, plus the first
+   `AdminUser` as **owner**. Email verification.
+2. **Create the brigade/station** — reuse existing station creation + the RFS facilities
+   lookup (`rfsFacilitiesParser`) so they find their real brigade.
+3. **Choose a plan** → **Stripe Checkout** (hosted) → on success, a webhook flips the
+   org to `active` and writes entitlements.
+4. **Enrol devices** — generate `Device` accounts (extends today's brigade tokens); show
+   a QR to enrol each kiosk/tablet/phone.
+5. **Add members** — bulk import already exists; optionally **invite** members to activate
+   a personal login (email/SMS claim link).
+6. **Go live.** Trial → paid handled by Stripe; entitlements gate features.
+
+## 4. Device-type accounts
+
+Formalise `BrigadeAccessToken` into a first-class **`Device`**:
+
+```typescript
+export interface Device {
+  id: string;
+  organizationId: string;
+  stationId: string;
+  type: 'kiosk' | 'tablet' | 'phone' | 'wearable';  // wearable = headset for the AI agent
+  name: string;                 // "Main shed kiosk", "Captain's phone"
+  token: string;                // unguessable credential (UUID; same model as today)
+  status: 'active' | 'revoked';
+  lastSeenAt?: string;
+  createdAt: string;
+  expiresAt?: string;
+}
+```
+
+- Backward compatible: existing `kioskToken`/`BrigadeAccessToken` map onto `Device` rows
+  of type `kiosk`.
+- Plans cap device **count by type** (see pricing). The AI voice agent runs on a
+  `phone`/`wearable` device account.
+- Reuses the existing kiosk-mode middleware and token validation.
+
+## 5. Member account activation
+
+Members stay free and unlimited; "activation" gives a member their own login (for
+profile, self sign-in, and — later — to be the speaker identity on an AI session):
+
+```typescript
+export interface Member {            // additive fields
+  // ...existing
+  email?: string;
+  authStatus?: 'none' | 'invited' | 'active';
+  userId?: string;                   // → a credential record once activated
+  invitedAt?: string;
+}
+```
+
+Activation = send a claim link → member sets a password / passwordless → `authStatus`
+becomes `active`. No plan seat cost (keeps brigades' volunteer rosters frictionless);
+member **logins** can be a Basic+ feature if we ever need to gate it.
+
+## 6. Billing & e-commerce (Stripe)
+
+**Stripe is the right choice.** Recommended surface:
+
+| Need | Stripe product |
+|---|---|
+| Take payment at signup | **Checkout** (hosted; PCI scope = SAQ-A, no card data on our servers) |
+| Subscriptions, plans, proration, trials | **Billing** |
+| Let brigades manage/cancel/upgrade + see invoices | **Customer Portal** |
+| Entitlement sync | **Webhooks** (`checkout.session.completed`, `customer.subscription.updated|deleted`, `invoice.paid`, `invoice.payment_failed`) |
+| GST | **Stripe Tax** (AU GST handled automatically) |
+| AI overage / packs | **Metered billing** (usage records) + one-off **Payment Links** |
+| Grant-funded brigades who can't use cards | **Invoicing** (annual invoice, pay by transfer) |
+
+**We store only** `stripeCustomerId` / `stripeSubscriptionId` / status on the
+`Organization`; Stripe is the source of truth. Webhooks are **signature-verified**; a
+`BillingEvent` audit row is written for each.
+
+**E-commerce beyond subscriptions** (later): a small storefront for one-off purchases —
+**AI session top-up packs** and optional **hardware bundles** (tablet + stand + headset).
+Stripe Checkout/Payment Links cover this without a separate cart.
+
+## 7. Pricing — assessment & recommendation
+
+### Cost model (per brigade / month)
+
+- **Infra (Basic):** shared scale-to-zero Container Apps + Table/Blob + capped App
+  Insights → **well under A$1/brigade**. Storage and compute are effectively free per
+  tenant at this scale.
+- **Stripe fee:** AU domestic card ≈ 1.75% + A$0.30; on A$10 that's ≈ **A$0.48 (≈5%)**.
+  Annual billing amortises the fixed A$0.30 (one charge vs twelve).
+- **Email/SMS** (verification, invites): cents.
+- **AI per voice session (~12 min):** STT ≈ A$0.20 + TTS ≈ A$0.08 + LLM (with prompt
+  caching) ≈ A$0.15–0.60 → **≈ A$0.40–0.90, call it ~A$0.60/session**.
+- **AI per brigade/month:** light use (weekly, 2–3 trucks ≈ 8–12 sessions) ≈ **A$5–7**;
+  heavy use (30–60 sessions) ≈ **A$18–36**.
+
+### What this means
+
+- **Basic at A$10/mo is very healthy** (≈90%+ margin) — infra is near-zero, only Stripe
+  fees matter. Your A$10 instinct is right.
+- **A flat A$15 AI tier does _not_ safely cover AI** — a light brigade is roughly
+  break-even and a heavy brigade is a clear loss. AI cost is **usage-driven**, so flat
+  pricing transfers all the risk to us.
+
+### Recommendation
+
+Keep the headline low to drive adoption, but make AI **fair-use metered** so price tracks
+cost:
+
+| Tier | Price (rec.) | Includes |
+|---|---|---|
+| **Community (Free)** | A$0 | 1 station, manual sign-in + truck check, capped members/devices. Adoption funnel + goodwill for volunteer brigades. |
+| **Basic** | **A$10/mo** or **A$100/yr** (2 months free) | Full manual suite, unlimited members, multiple devices, reports + CSV export, real-time sync. |
+| **AI (Pro)** | **A$19/mo** or **A$190/yr**, *including* a fair-use allowance (~25 voice sessions/mo), then **~A$0.60/session** overage or top-up packs | Everything in Basic + the voice maintenance agent, zone-aware prompting, transcripts. |
+
+- If you want to **honour the A$15 number**, it's viable as the AI tier **with a tighter
+  allowance** (~15 sessions/mo) and the same overage — I'd just recommend A$19 with a
+  more generous cap as the safer default. Avoid **flat unlimited** AI unless priced ~A$25–29.
+- **Annual billing** (2 months free) is the single biggest lever: it cuts Stripe fee drag,
+  reduces churn, and suits grant/council-funded brigades who budget yearly.
+- Add **Stripe Tax** for GST from day one; show prices inc. GST to brigades.
+
+> Net: **Basic A$10**, **AI A$19 with fair-use metering** (or A$15 with a smaller included
+> allowance). Both protect margin while staying very reasonable for volunteer orgs.
+
+## 8. Entitlements & feature gating
+
+- `Organization.entitlements` is a derived snapshot (from plan + subscription status),
+  refreshed by Stripe webhooks: `{ aiEnabled, maxStations, maxDevices, aiIncludedSessions }`.
+- A gate (extends the existing `flexibleAuth`/middleware) blocks AI endpoints when
+  `aiEnabled` is false or the monthly allowance is exhausted (→ prompt to top up).
+- Degrades gracefully: `past_due` keeps read access but suspends AI; `canceled` reverts to
+  the Community feature set rather than locking data out.
+
+## 9. Schema deltas (additive, both DB twins)
+
+**New entities**
+```typescript
+interface Organization {
+  id: string; name: string; billingEmail: string;
+  stripeCustomerId?: string; stripeSubscriptionId?: string;
+  planCode: 'community' | 'basic' | 'ai';
+  status: 'trialing' | 'active' | 'past_due' | 'canceled';
+  entitlements: { aiEnabled: boolean; maxStations: number; maxDevices: number; aiIncludedSessions: number };
+  createdAt: string; updatedAt?: string;
+}
+interface Device { /* §4 */ }
+interface UsageRecord {            // AI metering / fair-use accounting
+  id: string; organizationId: string; type: 'ai-voice-session';
+  quantity: number; sessionId?: string; occurredAt: string;
+}
+interface BillingEvent {           // webhook audit trail
+  id: string; organizationId: string; stripeEventId: string;
+  type: string; payloadSummary: string; receivedAt: string;
+}
+```
+
+**Extensions (all optional / backward-compatible)**
+- `Station` += `organizationId`
+- `AdminUser` += `organizationId`, role `'owner'`
+- `Member` += `email`, `authStatus`, `userId`, `invitedAt` (§5)
+
+**Plans** are a small code-level catalog (like `checklistVocabulary.ts`) mapped to Stripe
+Price IDs via config — not a DB table.
+
+**Isolation:** `organizationId` becomes the outer tenant boundary; all queries already
+scoped by `stationId` gain an org check at the station→org link. Existing single-tenant
+data migrates under one default Organization (mirrors the `default-station` pattern).
+
+## 10. Security & compliance
+
+- **PCI:** card data never touches our servers (Checkout/Portal) → SAQ-A.
+- **Webhooks:** verify Stripe signatures; idempotent by `stripeEventId`.
+- **Tenant isolation:** enforce `organizationId` on every cross-station/admin query;
+  add tests mirroring the existing multi-station isolation suite.
+- **Data on cancel:** retain (don't delete) per a documented retention policy; downgrade
+  features, keep the brigade's records exportable.
+
+## 11. Phased delivery
+
+| Phase | Scope | Notes |
+|---|---|---|
+| **A — Tenant model** | `Organization`, link Stations, scope AdminUsers, default-org migration | foundation; no billing yet |
+| **B — Billing + signup** | Stripe Checkout/Billing/Portal, webhooks, entitlements, feature gating, self-service signup + email verify | the commercial core |
+| **C — Devices + members** | `Device` accounts (formalise tokens) + member activation/invites | |
+| **D — AI metering + storefront** | `UsageRecord` metering, fair-use/overage, top-up packs, optional hardware store | depends on the AI agent (Phase 2 of that design) |
+
+## 12. Open questions
+
+- Free tier limits (members/devices) that drive upgrades without alienating volunteers.
+- Trial length (14 vs 30 days) and whether AI is trialable.
+- Per-org vs per-brigade billing for multi-brigade groups (e.g., a district running several).
+- Do we meter AI by **session** or by **audio-minute**? (Session is simpler to explain.)
+- Grant/PO workflow: how many brigades will need Stripe **Invoicing** vs cards.
+- Member-login rollout: needed for the AI speaker identity, or keep device-level for now?


### PR DESCRIPTION
Design-only PR (docs) for future releases — **no code changes**. Two related forward-looking designs.

---

## 1. AI voice/vision truck-maintenance agent — `docs/AI_MAINTENANCE_AGENT_DESIGN.md`

Hands-free assistant: member says *"I'm starting the Cat 1 tanker,"* narrates as they work, agent prompts follow-ups **in the same physical area**, tuned to brigade layout + vehicle age/quirks. Voice first; vision later.

**Decisions baked in:** cloud-only first; produce the **same auditable `CheckRun`/`CheckResult`** **plus** a narrative transcript; **per-truck zones** from a standard starter taxonomy; **hybrid** structured-data + LLM nuance.

**Schema (additive, both DB twins):** new `ApplianceZone` / `ApplianceEquipment` / `AgentSession` / `AgentTurn`; optional fields on `Appliance` / `ChecklistItem` / `CheckRun` / `CheckResult`. Every truck stays unique; canonical codes keep cross-brigade analytics.

## 2. Self-service sign-up, multi-tenant billing & commercialization — `docs/SAAS_COMMERCIALIZATION_DESIGN.md`

Brigade signs up online → picks a plan → pays (Stripe) → enrols device accounts → activates members. AI agent sold as a paid add-on.

- **Tenancy:** new **`Organization`** billing tenant above the existing `brigadeId`/`stationId`; formalise `BrigadeAccessToken` → first-class **`Device`** accounts (kiosk/tablet/phone/wearable); optional member activation. `organizationId` = outer isolation boundary; existing data migrates under one default org.
- **Stripe (endorsed):** Checkout + Billing + Customer Portal + signed webhooks → entitlements; Stripe Tax (GST); metered AI overage; Invoicing for grant-funded brigades. Only Stripe IDs stored (PCI SAQ-A).
- **Pricing assessment & recommendation:** infra is < A$1/brigade/mo so **Basic A$10 is ~90% margin**. AI is **usage-driven** (~A$0.60/voice session; ~A$5–7/mo light, A$18–36 heavy), so a **flat A$15 AI tier under-covers heavy users**. Recommend **Community (free) / Basic A$10 / AI (Pro) A$19 with fair-use metering** (or honour A$15 with a tighter included allowance), plus **annual billing (2 months free)**.
- **Schema (additive):** `Organization`, `Device`, `UsageRecord`, `BillingEvent`; `+organizationId` on `Station`/`AdminUser`; member auth fields. Plans = code-level catalog → Stripe Price IDs.

---

Both are **design only** — nothing implemented. Intended as RFCs to review before scheduling. The two are linked: the AI tier in design #2 gates the agent in design #1, and short bursty voice sessions fit the scale-to-zero Container Apps option from the IaC spike (#514).

https://claude.ai/code/session_01FRvjwRLpCfeejUsvLJ7uYU