### PR TITLE
Full review: fix activity-delete persistence, auto-expiry race, N+1 queries + in-modal activity creation UX

### DIFF
--- a/backend/src/middleware/activityValidation.ts
+++ b/backend/src/middleware/activityValidation.ts
@@ -7,7 +7,7 @@
  * - Protecting against XSS attacks
  */
 
-import { body } from 'express-validator';
+import { body, param } from 'express-validator';
 
 /**
  * Validation for creating a custom activity
@@ -38,6 +38,19 @@ export const validateCreateActivity = [
  * Validation for setting active activity
  * POST /api/activities/active
  */
+/**
+ * Validation for activity ID route parameter
+ * DELETE /api/activities/:activityId
+ */
+export const validateActivityId = [
+  param('activityId')
+    .trim()
+    .notEmpty()
+    .withMessage('Activity ID is required')
+    .isLength({ max: 100 })
+    .withMessage('Activity ID is invalid'),
+];
+
 export const validateSetActiveActivity = [
   body('activityId')
     .trim()

--- a/backend/src/routes/activities.ts
+++ b/backend/src/routes/activities.ts
@@ -19,7 +19,9 @@ import { ensureDatabase } from '../services/dbFactory';
 import {
   validateCreateActivity,
   validateSetActiveActivity,
+  validateActivityId,
 } from '../middleware/activityValidation';
+import { DEFAULT_STATION_ID, getEffectiveStationId } from '../constants/stations';
 import { handleValidationErrors } from '../middleware/validationHandler';
 import { stationMiddleware, getStationIdFromRequest } from '../middleware/stationMiddleware';
 import { flexibleAuth } from '../middleware/flexibleAuth';
@@ -75,7 +77,8 @@ router.get('/active', flexibleAuth({ scope: 'station' }), async (req, res) => {
 });
 
 // Set active activity (per-station)
-router.post('/active', validateSetActiveActivity, handleValidationErrors, async (req: Request, res: Response) => {
+// Protected by flexibleAuth when ENABLE_DATA_PROTECTION=true
+router.post('/active', validateSetActiveActivity, handleValidationErrors, flexibleAuth({ scope: 'station' }), async (req: Request, res: Response) => {
   try {
     const db = await ensureDatabase(req.isDemoMode);
     const { activityId, setBy } = req.body;
@@ -106,7 +109,8 @@ router.post('/active', validateSetActiveActivity, handleValidationErrors, async 
 });
 
 // Create custom activity (assigns station)
-router.post('/', validateCreateActivity, handleValidationErrors, async (req: Request, res: Response) => {
+// Protected by flexibleAuth when ENABLE_DATA_PROTECTION=true
+router.post('/', validateCreateActivity, handleValidationErrors, flexibleAuth({ scope: 'station' }), async (req: Request, res: Response) => {
   try {
     const db = await ensureDatabase(req.isDemoMode);
     const { name, createdBy } = req.body;
@@ -126,28 +130,34 @@ router.post('/', validateCreateActivity, handleValidationErrors, async (req: Req
   }
 });
 
-// Delete activity (soft delete)
-router.delete('/:activityId', async (req: Request, res: Response) => {
+// Delete activity (soft delete, persisted via the database service)
+// Protected by flexibleAuth when ENABLE_DATA_PROTECTION=true
+router.delete('/:activityId', validateActivityId, handleValidationErrors, flexibleAuth({ scope: 'station' }), async (req: Request, res: Response) => {
   try {
     const db = await ensureDatabase(req.isDemoMode);
     const { activityId } = req.params;
-    
-    if (!activityId) {
-      return res.status(400).json({ error: 'Activity ID is required' });
-    }
+    const stationId = getStationIdFromRequest(req);
 
-    // Get the activity first
     const activity = await db.getActivityById(activityId);
-    
+
     if (!activity) {
       return res.status(404).json({ error: 'Activity not found' });
     }
 
-    // Soft delete by setting isDeleted flag
-    // Note: This is a workaround until updateActivity method is added to IDatabase
-    (activity as any).isDeleted = true;
+    // Only allow deleting activities visible to this station
+    // (station-specific activities of the same station, or shared defaults)
+    const activityStationId = getEffectiveStationId(activity.stationId);
+    if (activityStationId !== getEffectiveStationId(stationId) && activityStationId !== DEFAULT_STATION_ID) {
+      return res.status(404).json({ error: 'Activity not found' });
+    }
 
-    res.json({ message: 'Activity deleted successfully', activity });
+    const deletedActivity = await db.deleteActivity(activityId);
+
+    if (!deletedActivity) {
+      return res.status(404).json({ error: 'Activity not found' });
+    }
+
+    res.json({ message: 'Activity deleted successfully', activity: deletedActivity });
   } catch (error) {
     logger.error('Error deleting activity', { 
       error, 

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -18,6 +18,7 @@
 import { Member, Activity, CheckIn, ActiveActivity, CheckInWithDetails, Event, EventParticipant, EventWithParticipants, Station, StationCreationPayload, EventAuditLog, DeviceInfo, LocationInfo } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 import { autoExpireEvents } from './rolloverService';
+import type { IDatabase } from './dbFactory';
 import { DEFAULT_STATION_ID, DEMO_STATION_ID, DEMO_BRIGADE_ID, getEffectiveStationId } from '../constants/stations';
 import { DEFAULT_MEMBERS, buildDisplayName } from './defaultMembers';
 import { logger } from './logger';
@@ -485,6 +486,19 @@ class DatabaseService {
     return activity;
   }
 
+  /**
+   * Soft delete an activity (hidden from getAllActivities, retained for history)
+   */
+  deleteActivity(id: string): Activity | null {
+    const activity = this.activities.get(id);
+    if (!activity) {
+      return null;
+    }
+    activity.isDeleted = true;
+    this.activities.set(id, activity);
+    return activity;
+  }
+
   // Active Activity methods
   getActiveActivity(stationId?: string): ActiveActivity | null {
     // For multi-station support, we need to track active activity per station
@@ -666,24 +680,25 @@ class DatabaseService {
    * Expired events remain visible in getEvents(), they're just marked as inactive.
    * @param stationId - Optional station ID to filter by
    */
-  getActiveEvents(stationId?: string): Event[] {
+  async getActiveEvents(stationId?: string): Promise<Event[]> {
     let activeEvents = Array.from(this.events.values())
       .filter(event => event.isActive);
-    
+
     if (stationId) {
       activeEvents = activeEvents.filter(e => getEffectiveStationId(e.stationId) === stationId);
     }
-    
+
     activeEvents = activeEvents.sort((a, b) => b.startTime.getTime() - a.startTime.getTime());
-    
-    // Auto-expire events that have exceeded time limit
-    // This is synchronous because in-memory DB operations are instant
-    autoExpireEvents(activeEvents, this as any).then(() => {
-      // Events have been marked inactive in the database
-    }).catch(err => {
+
+    // Auto-expire events that have exceeded the time limit before returning,
+    // so expired events are never included in the response (matches the
+    // Table Storage implementation, which also awaits expiry)
+    try {
+      await autoExpireEvents(activeEvents, this as IDatabase);
+    } catch (err) {
       logger.error('Error auto-expiring events', { error: err });
-    });
-    
+    }
+
     // Return only currently active events (excluding ones we just expired)
     let result = Array.from(this.events.values())
       .filter(event => event.isActive);

--- a/backend/src/services/dbFactory.ts
+++ b/backend/src/services/dbFactory.ts
@@ -48,6 +48,7 @@ export interface IDatabase {
   getAllActivities(stationId?: string): Promise<Activity[]> | Activity[];
   getActivityById(id: string): Promise<Activity | null | undefined> | Activity | null | undefined;
   createActivity(name: string, createdBy?: string, stationId?: string): Promise<Activity> | Activity;
+  deleteActivity(id: string): Promise<Activity | null> | Activity | null; // Soft delete
   
   // Active Activity
   getActiveActivity(stationId?: string): Promise<ActiveActivity | null> | ActiveActivity | null;

--- a/backend/src/services/tableStorageDatabase.ts
+++ b/backend/src/services/tableStorageDatabase.ts
@@ -334,13 +334,16 @@ export class TableStorageDatabase {
       checkInCounts.set(p.memberId, current);
     });
     
-    // Get currently checked-in members
+    // Get currently checked-in members (fetch all events' participants in parallel
+    // rather than one sequential query per event)
     const activeEvents = await this.getActiveEvents();
     const checkedInMemberIds = new Set<string>();
-    for (const event of activeEvents) {
-      const eventParticipants = await this.getEventParticipants(event.id);
+    const activeEventParticipants = await Promise.all(
+      activeEvents.map(event => this.getEventParticipants(event.id))
+    );
+    activeEventParticipants.forEach(eventParticipants => {
       eventParticipants.forEach(p => checkedInMemberIds.add(p.memberId));
-    }
+    });
     
     // Apply search filter
     if (options?.search) {
@@ -1649,14 +1652,14 @@ export class TableStorageDatabase {
    */
   private async getAllEventParticipants(startDate: Date, endDate: Date, stationId?: string): Promise<EventParticipant[]> {
     const events = await this.getEventsByDateRange(startDate, endDate, stationId);
-    const allParticipants: EventParticipant[] = [];
-    
-    for (const event of events) {
-      const participants = await this.getEventParticipants(event.id);
-      allParticipants.push(...participants);
-    }
-    
-    return allParticipants;
+
+    // Fetch participants for all events in parallel rather than one sequential
+    // query per event (this is called on every member-list fetch)
+    const participantsPerEvent = await Promise.all(
+      events.map(event => this.getEventParticipants(event.id))
+    );
+
+    return participantsPerEvent.flat();
   }
 
   // ============================================

--- a/docs/AS_BUILT.md
+++ b/docs/AS_BUILT.md
@@ -1144,11 +1144,12 @@ The API register contains:
 - `PUT /api/members/:id` - Update member
 - `GET /api/members/:id/history` - Get member check-in history
 
-**Activities (4 endpoints)**
+**Activities (5 endpoints)**
 - `GET /api/activities` - List all activities
 - `POST /api/activities` - Create custom activity
 - `GET /api/activities/active` - Get current active activity
 - `POST /api/activities/active` - Set active activity
+- `DELETE /api/activities/:activityId` - Soft delete activity (station-scoped)
 
 **Check-ins (3 endpoints)**
 - `GET /api/checkins/active` - Get active check-ins

--- a/docs/api_register.json
+++ b/docs/api_register.json
@@ -785,6 +785,60 @@
           ]
         }
       }
+    },
+    "DELETE /api/activities/:activityId": {
+      "method": "DELETE",
+      "path": "/api/activities/:activityId",
+      "description": "Soft delete an activity (hidden from lists, retained for history). Station-scoped: only activities visible to the requesting station can be deleted.",
+      "authentication": "flexibleAuth (station scope) when ENABLE_DATA_PROTECTION=true",
+      "parameters": {
+        "activityId": {
+          "in": "path",
+          "type": "string",
+          "required": true,
+          "description": "Activity UUID"
+        }
+      },
+      "requestBody": null,
+      "responses": {
+        "200": {
+          "description": "Activity soft-deleted",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "activity": {
+                "$ref": "#/definitions/Activity"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Invalid activity ID"
+        },
+        "404": {
+          "description": "Activity not found (or belongs to another station)"
+        },
+        "500": {
+          "description": "Server error"
+        }
+      },
+      "implementation": "backend/src/routes/activities.ts:135",
+      "security": {
+        "rateLimiting": {
+          "enabled": true,
+          "maxRequests": 84,
+          "windowMs": 300000,
+          "description": "Rate limited to ≈1,000 requests per hour per IP (≈84 per 5-minute window) (configurable)",
+          "headers": [
+            "RateLimit-Limit",
+            "RateLimit-Remaining",
+            "RateLimit-Reset"
+          ]
+        }
+      }
     }
   },
   "checkins": {

--- a/docs/function_register.json
+++ b/docs/function_register.json
@@ -256,6 +256,19 @@
           "complexity": "O(1)",
           "sideEffects": "Adds custom activity to database"
         },
+        "deleteActivity": {
+          "signature": "deleteActivity(id: string): Activity | null",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Activity UUID"
+            }
+          ],
+          "returns": "Activity | null",
+          "complexity": "O(1)",
+          "sideEffects": "Soft-deletes activity (sets isDeleted flag; hidden from getAllActivities)"
+        },
         "getActiveActivity": {
           "signature": "getActiveActivity(): ActiveActivity | null",
           "line": 270,
@@ -377,11 +390,11 @@
           "sideEffects": "none"
         },
         "getActiveEvents": {
-          "signature": "getActiveEvents(): Event[]",
+          "signature": "getActiveEvents(stationId?: string): Promise<Event[]>",
           "line": 354,
-          "returns": "Event[]",
+          "returns": "Promise<Event[]>",
           "complexity": "O(n)",
-          "sideEffects": "none"
+          "sideEffects": "Auto-expires events past the expiry window (awaited before returning)"
         },
         "getEventById": {
           "signature": "getEventById(id: string): Event | undefined",

--- a/frontend/src/components/MemberList.tsx
+++ b/frontend/src/components/MemberList.tsx
@@ -126,6 +126,7 @@ export function MemberList({
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [pendingOperations, setPendingOperations] = useState<Map<string, 'signing-in' | 'signing-out'>>(new Map());
   const membersContainerRef = useRef<HTMLDivElement>(null);
+  const membersGridRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const addMemberInputRef = useRef<HTMLInputElement>(null);
   
@@ -202,6 +203,14 @@ export function MemberList({
 
     fetchMembers();
   }, [debouncedSearchTerm, filter, sort, initialMembers, filteredMembers.length]);
+
+  // Scroll back to the top of the list whenever search/filter/sort changes,
+  // so users aren't left stranded mid-list looking at fewer results
+  useEffect(() => {
+    if (membersGridRef.current) {
+      membersGridRef.current.scrollTop = 0;
+    }
+  }, [debouncedSearchTerm, filter, sort, selectedLetter]);
 
   // Apply letter filter locally (after API filtering)
   // Also apply partitioning: active members (within last year) at top, inactive at bottom
@@ -435,7 +444,7 @@ export function MemberList({
             <span>Refreshing...</span>
           </div>
         )}
-        <div className="members-grid" role="list" aria-label="Member list">
+        <div className="members-grid" ref={membersGridRef} role="list" aria-label="Member list">
           {displayedMembers.length > 0 ? (
             displayedMembers.map(member => {
               const isCheckedIn = checkedInMemberIds.has(member.id);

--- a/frontend/src/components/NewEventModal.css
+++ b/frontend/src/components/NewEventModal.css
@@ -184,6 +184,82 @@
   letter-spacing: 0.5px;
 }
 
+.activity-empty-state {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius-lg);
+  margin-bottom: 1.5rem;
+}
+
+.activity-empty-state-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.activity-empty-state-hint {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.add-activity-toggle {
+  width: 100%;
+  margin-top: 1.25rem;
+  padding: 1rem;
+  min-height: 60px;
+  background: transparent;
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 1.05rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.add-activity-toggle:hover {
+  border-color: var(--rfs-lime);
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+
+.add-activity-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.add-activity-input {
+  flex: 1 1 200px;
+  min-height: 60px;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  color: var(--text-primary);
+  font-size: 1.05rem;
+}
+
+.add-activity-input:focus {
+  outline: none;
+  border-color: var(--rfs-lime);
+  box-shadow: 0 0 0 3px rgba(203, 219, 42, 0.2);
+}
+
+.add-activity-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.add-activity-actions .btn-primary,
+.add-activity-actions .btn-secondary {
+  min-height: 60px;
+}
+
 .activity-delete-btn {
   position: absolute;
   top: 5px;

--- a/frontend/src/components/NewEventModal.tsx
+++ b/frontend/src/components/NewEventModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type KeyboardEvent, type MouseEvent } from 'react';
+import { useState, useEffect, useRef, type KeyboardEvent, type MouseEvent } from 'react';
 import type { Activity } from '../types';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import './NewEventModal.css';
@@ -8,16 +8,48 @@ interface NewEventModalProps {
   activities: Activity[];
   onClose: () => void;
   onCreate: (activityId: string) => void;
+  onCreateActivity?: (name: string) => Promise<Activity | null>;
   onDeleteActivity: (activityId: string) => void;
 }
 
-export function NewEventModal({ isOpen, activities, onClose, onCreate, onDeleteActivity }: NewEventModalProps) {
+export function NewEventModal({ isOpen, activities, onClose, onCreate, onCreateActivity, onDeleteActivity }: NewEventModalProps) {
   const [selectedActivityId, setSelectedActivityId] = useState<string>('');
+  const [showAddActivity, setShowAddActivity] = useState(false);
+  const [newActivityName, setNewActivityName] = useState('');
+  const [isCreatingActivity, setIsCreatingActivity] = useState(false);
+  const addActivityInputRef = useRef<HTMLInputElement>(null);
   const modalRef = useFocusTrap<HTMLDivElement>(isOpen);
   const handleClose = () => {
     setSelectedActivityId('');
+    setShowAddActivity(false);
+    setNewActivityName('');
     onClose();
   };
+
+  const handleAddActivity = async () => {
+    const name = newActivityName.trim();
+    if (!name || !onCreateActivity || isCreatingActivity) return;
+
+    setIsCreatingActivity(true);
+    try {
+      const activity = await onCreateActivity(name);
+      if (activity) {
+        // Select the new activity so the user can start the event immediately
+        setSelectedActivityId(activity.id);
+        setNewActivityName('');
+        setShowAddActivity(false);
+      }
+    } finally {
+      setIsCreatingActivity(false);
+    }
+  };
+
+  // Focus the name input when the add-activity form opens
+  useEffect(() => {
+    if (showAddActivity) {
+      addActivityInputRef.current?.focus();
+    }
+  }, [showAddActivity]);
 
   const handleOverlayKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.target !== event.currentTarget) return;
@@ -48,6 +80,8 @@ export function NewEventModal({ isOpen, activities, onClose, onCreate, onDeleteA
     const handleEscape = (event: Event) => {
       if ((event as globalThis.KeyboardEvent).key === 'Escape') {
         setSelectedActivityId('');
+        setShowAddActivity(false);
+        setNewActivityName('');
         onClose();
       }
     };
@@ -92,6 +126,15 @@ export function NewEventModal({ isOpen, activities, onClose, onCreate, onDeleteA
             Select an activity type to start a new event. Participants can sign in to this event.
           </p>
 
+          {activities.length === 0 && (
+            <div className="activity-empty-state" role="status">
+              <p className="activity-empty-state-title">No activity types yet</p>
+              <p className="activity-empty-state-hint">
+                Add your first activity type below to start an event.
+              </p>
+            </div>
+          )}
+
           <div className="activity-grid" role="radiogroup" aria-label="Activity type selection">
             {activities.map((activity) => (
               <div key={activity.id} className="activity-option-wrapper">
@@ -128,6 +171,60 @@ export function NewEventModal({ isOpen, activities, onClose, onCreate, onDeleteA
               </div>
             ))}
           </div>
+
+          {onCreateActivity && (
+            showAddActivity ? (
+              <div className="add-activity-form">
+                <label htmlFor="new-activity-name" className="sr-only">New activity name</label>
+                <input
+                  id="new-activity-name"
+                  ref={addActivityInputRef}
+                  type="text"
+                  className="add-activity-input"
+                  placeholder="Activity name..."
+                  value={newActivityName}
+                  maxLength={200}
+                  onChange={(e) => setNewActivityName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddActivity();
+                    }
+                  }}
+                  disabled={isCreatingActivity}
+                />
+                <div className="add-activity-actions">
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    onClick={handleAddActivity}
+                    disabled={!newActivityName.trim() || isCreatingActivity}
+                  >
+                    {isCreatingActivity ? 'Adding…' : 'Add'}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={() => {
+                      setShowAddActivity(false);
+                      setNewActivityName('');
+                    }}
+                    disabled={isCreatingActivity}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="add-activity-toggle"
+                onClick={() => setShowAddActivity(true)}
+              >
+                + Add activity type
+              </button>
+            )
+          )}
         </div>
 
         <div className="modal-footer">

--- a/frontend/src/features/signin/SignInPage.tsx
+++ b/frontend/src/features/signin/SignInPage.tsx
@@ -241,7 +241,7 @@ export function SignInPage() {
   const handleCreateEvent = async (activityId: string) => {
     try {
       const event = await api.createEvent(activityId);
-      setEvents([event, ...events]);
+      setEvents(prev => [event, ...prev]);
       setSelectedEventId(event.id);
       emit('event-created', event);
       
@@ -378,7 +378,7 @@ export function SignInPage() {
   const handleAddMember = async (name: string, rank?: string | null) => {
     try {
       const member = await api.createMember(name, rank);
-      setMembers([...members, member]);
+      setMembers(prev => [...prev, member]);
       announce(`Success: ${name} added as new member`, 'polite');
       showSuccess(`${name} added as new member`);
       emit('member-added', member);
@@ -395,14 +395,16 @@ export function SignInPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [offset, loadingMore]);
 
-  const handleCreateActivity = async (name: string) => {
+  const handleCreateActivity = async (name: string): Promise<Activity | null> => {
     try {
       const activity = await api.createActivity(name);
-      setActivities([...activities, activity]);
+      setActivities(prev => [...prev, activity]);
       showSuccess(`Activity "${name}" created`);
+      return activity;
     } catch (err) {
       console.error('Error creating activity:', err);
       showError(formatErrorMessage(err));
+      return null;
     }
   };
 
@@ -411,7 +413,7 @@ export function SignInPage() {
       await api.deleteActivity(activityId);
       
       // Remove the activity from the list
-      setActivities(activities.filter(a => a.id !== activityId));
+      setActivities(prev => prev.filter(a => a.id !== activityId));
       
       emit('activity-deleted', { activityId });
       showSuccess('Activity deleted');
@@ -424,7 +426,7 @@ export function SignInPage() {
   const handleUpdateMember = async (id: string, name: string) => {
     try {
       const updatedMember = await api.updateMember(id, name);
-      setMembers(members.map(m => m.id === id ? updatedMember : m));
+      setMembers(prev => prev.map(m => m.id === id ? updatedMember : m));
       emit('member-update', updatedMember);
     } catch (err) {
       console.error('Error updating member:', err);
@@ -669,6 +671,7 @@ export function SignInPage() {
         activities={activities}
         onClose={() => setShowNewEventModal(false)}
         onCreate={handleCreateEvent}
+        onCreateActivity={handleCreateActivity}
         onDeleteActivity={handleDeleteActivity}
       />
 


### PR DESCRIPTION
# Full review — targeted technical fixes + UX uplift

A structured review of the backend and frontend surfaced several confirmed bugs and one clear UX gap. This PR fixes the high-confidence items.

## Backend fixes

### 1. Activity deletion was never persisted (data bug)
`DELETE /api/activities/:activityId` soft-deleted by mutating the object returned from `getActivityById` (`(activity as any).isDeleted = true`). For Table Storage that object is a fresh copy, so the deletion was **silently lost** — "deleted" activities reappeared in production. Now:
- `deleteActivity()` added to the `IDatabase` interface and the in-memory `DatabaseService` (the Table Storage twin already had it but it was never called).
- The route calls `db.deleteActivity()`, validates the `activityId` param, enforces station scoping (can only delete activities visible to the requesting station), and is protected by `flexibleAuth` — previously the GET endpoints were protected but the mutations were not.

### 2. Race in in-memory `getActiveEvents()` (dev/prod divergence)
The in-memory implementation fired `autoExpireEvents()` without awaiting (the comment claimed it was synchronous; it isn't), so expired events could intermittently appear in responses. The Table Storage twin awaits it. The in-memory version now awaits too, so both implementations behave identically.

### 3. N+1 Azure Table queries on every member-list fetch (perf)
`getAllMembers()` and `getAllEventParticipants()` in the Table Storage service issued one *sequential* query per event. With many events in the 6-month reporting window this serialized dozens of round trips on a hot path. Both now fan out with `Promise.all` (same semantics, latency drops from O(n) round trips to O(1)).

## Frontend fixes

### 4. Stale-closure state updates in `SignInPage`
`handleCreateEvent`, `handleAddMember`, `handleCreateActivity`, `handleDeleteActivity`, and `handleUpdateMember` wrote state from captured `events`/`members`/`activities` arrays — a socket-driven refresh landing mid-request would be overwritten. All now use functional `setState(prev => …)` updates.

## UX uplift

### 5. Create activity types from the New Event modal
Previously, if a station had no activity types, the "Start New Event" modal showed a **silent blank grid**, and the only way to add an activity type was a browser `prompt()` buried in the header menu — not kiosk-friendly. Now the modal:
- Shows a clear empty state explaining what to do,
- Has a touch-friendly "+ Add activity type" inline form (≥60px targets, RFS theme vars, focus management, Enter-to-submit),
- Auto-selects the newly created activity so the user can immediately tap "Start Event".

### 6. Member list scrolls back to top on search/filter changes
Changing search/filter/sort/letter while scrolled deep in the member list left users staring at empty space below fewer results. The list now resets to the top on filter changes.

## Review findings deliberately not changed
- **Server-side socket emissions for event routes**: clients relay `event-created`/`participant-change` through the socket handlers in `index.ts` by design; adding server-side emits would double-fire updates.
- **A–Z letter rail touch targets (32px on desktop)**: 26 buttons in a vertical rail can't each hit 60px within viewport height; resizing it is a design decision, flagging rather than changing.
- Demo station auth bypass left as-is (intentional per CLAUDE.md).

## Docs
- `docs/api_register.json`: registered `DELETE /api/activities/:activityId` (was undocumented).
- `docs/function_register.json`: added `deleteActivity`, updated `getActiveEvents` signature.
- `docs/AS_BUILT.md`: activities endpoint list updated (4 → 5).
- Registries pass `scripts/validate-registries.sh`.

## Verification
- Backend: `tsc --noEmit` clean, **537/537 Jest tests pass** (1 skipped).
- Frontend: ESLint zero warnings, `tsc -b` clean, `vite build` succeeds, **442/442 Vitest tests pass** (16 skipped).
- ⚠️ iPad portrait/landscape screenshots of the modal change could not be captured in this environment (no Playwright/browser available) — the modal changes follow existing CSS vars/BEM conventions and ≥60px touch targets; happy to describe or adjust on review.

https://claude.ai/code/session_011dhtSLyQmBSLUJw4gsFS9e

---
_Generated by [Claude Code](https://claude.ai/code/session_011dhtSLyQmBSLUJw4gsFS9e)_