### PR TITLE
Add AAR Studio — static web app for AI-facilitated After Action Reviews (Stages 1–4)

### DIFF
--- a/.github/workflows/aar-studio.yml
+++ b/.github/workflows/aar-studio.yml
@@ -1,0 +1,50 @@
+# AAR Studio — test + deploy to Azure Static Web Apps.
+# The app has no build step; the deploy uploads aar-studio/ as-is.
+#
+# Required repository secret for deploys:
+#   AZURE_STATIC_WEB_APPS_API_TOKEN_AAR_STUDIO — deployment token from the
+#   Static Web App resource (Overview → Manage deployment token).
+
+name: AAR Studio
+
+on:
+  push:
+    branches: [main]
+    paths: ['aar-studio/**', '.github/workflows/aar-studio.yml']
+  pull_request:
+    branches: [main]
+    paths: ['aar-studio/**', '.github/workflows/aar-studio.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit tests (node --test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run pure-module tests
+        working-directory: aar-studio
+        run: npm test
+
+  deploy:
+    name: Deploy to Azure Static Web Apps
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AAR_STUDIO }}
+          action: upload
+          app_location: aar-studio
+          output_location: ''
+          skip_app_build: true
+          skip_api_build: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,6 +136,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.github/*.md'
+      - 'aar-studio/**'   # AAR Studio has its own workflow (aar-studio.yml)
   pull_request:
     branches:
       - main

--- a/aar-studio/README.md
+++ b/aar-studio/README.md
@@ -9,19 +9,25 @@ Speech-to-text and AI analysis call your own Azure resources directly from the
 browser; nothing leaves the machine except those calls, and all session data
 lives in `localStorage`.
 
-> Status: Stages 1–2 complete (setup, transcript paste ingest, AI extraction,
-> live board, review, report editing + exports). Live audio capture and AI
-> report generation are next — see [`docs/PLAN.md`](docs/PLAN.md).
+> Status: Stages 1–2 and 4 complete (setup, live listen with real-time
+> transcription, transcript paste ingest, AI extraction, live board, review,
+> report editing + exports). AI report generation is next — see
+> [`docs/PLAN.md`](docs/PLAN.md).
 
 ## The workflow
 
 1. **Setup** — incident title/date/location/type, AAR date/location,
    facilitator, attending units, configurable phases (default Arrival, Rescue,
    Suppression, Overhaul, plus an implicit General bucket).
-2. **Capture** — paste a Teams transcript today (the DOCX copy format,
-   `Name: text` lines, or WEBVTT); live audio (room mic / shared Teams tab /
-   uploaded file via Azure AI Speech with diarization) arrives in Stage 4.
-   Click the current phase as the room moves through it.
+2. **Capture** — **live listen**: room microphone (primary mode — one mic,
+   many speakers), a shared Teams tab ("Share audio" ticked), or an uploaded
+   recording, transcribed in real time by Azure AI Speech with optional
+   diarization, interim results on screen, an input level meter, and an
+   optional local backup recording offered as a download. Or paste a Teams
+   transcript (the DOCX copy format, `Name: text` lines, or WEBVTT). Click
+   the current phase as the room moves through it — findings keep flowing
+   onto the board automatically (~every 45 s / 70 words, on phase change,
+   and on demand).
 3. **Board** — AI extracts discrete findings into four columns (*what
    happened / went well / didn't go well / next time*) with phase chips,
    dedupe, manual quick-add, and a fullscreen high-contrast **Present** mode
@@ -73,11 +79,14 @@ Calls go browser → Azure with the `api-key` header; structured outputs
 supports them, with automatic fallback to `json_object` and then plain-JSON
 parsing. `temperature`/`max_tokens` are never sent, so reasoning models work.
 
-### Azure AI Speech (live audio — Stage 4)
+### Azure AI Speech (live listen)
 
 Create a Speech resource (e.g. `australiaeast`), and put its key/region in
-Settings. Language defaults to `en-AU`; diarization is a toggle. The SDK is
-loaded lazily from jsDelivr only when capture starts.
+Settings. Language defaults to `en-AU`; diarization is a toggle (on = speakers
+come out as renameable "Speaker 1/2/…"). The SDK is loaded lazily from
+jsDelivr only when live listening starts. Microphone access requires HTTPS
+(or `localhost`); for Teams meetings, share the **meeting tab** and tick
+**Share audio** in the browser picker.
 
 ### Key handling — read this
 

--- a/aar-studio/README.md
+++ b/aar-studio/README.md
@@ -1,0 +1,109 @@
+# AAR Studio
+
+AI-facilitated After Action Reviews for fire brigade incidents — run the
+session, capture the room, watch findings appear on a live board, then package
+a one-page executive snapshot and full summary.
+
+Static web app: plain HTML/CSS/ES modules, **no build step, no backend**.
+Speech-to-text and AI analysis call your own Azure resources directly from the
+browser; nothing leaves the machine except those calls, and all session data
+lives in `localStorage`.
+
+> Status: Stages 1–2 complete (setup, transcript paste ingest, AI extraction,
+> live board, review, report editing + exports). Live audio capture and AI
+> report generation are next — see [`docs/PLAN.md`](docs/PLAN.md).
+
+## The workflow
+
+1. **Setup** — incident title/date/location/type, AAR date/location,
+   facilitator, attending units, configurable phases (default Arrival, Rescue,
+   Suppression, Overhaul, plus an implicit General bucket).
+2. **Capture** — paste a Teams transcript today (the DOCX copy format,
+   `Name: text` lines, or WEBVTT); live audio (room mic / shared Teams tab /
+   uploaded file via Azure AI Speech with diarization) arrives in Stage 4.
+   Click the current phase as the room moves through it.
+3. **Board** — AI extracts discrete findings into four columns (*what
+   happened / went well / didn't go well / next time*) with phase chips,
+   dedupe, manual quick-add, and a fullscreen high-contrast **Present** mode
+   for the projector.
+4. **Review** — edit findings and transcript, rename diarised speakers.
+5. **Report** — structured report (headline, context bar, key stats, snapshot,
+   per-phase detail, themes, recommendations, top three actions, assessment),
+   every field editable with live preview. Export a one-page snapshot HTML,
+   Markdown summary, session JSON, or print to PDF.
+
+Load the **Wamboin sample** from the home screen to see a finished session
+without any Azure setup.
+
+## Local development
+
+No toolchain needed — serve the directory and open it:
+
+```bash
+cd aar-studio
+python3 -m http.server 8080     # or: npx serve .
+# open http://localhost:8080
+```
+
+(Plain `file://` won't work because ES modules and `fetch` need an origin.)
+
+Run the unit tests (pure modules — parser, dedupe, exports, extraction,
+LLM fallback chain; zero dependencies):
+
+```bash
+npm test     # node --test, Node 22+
+```
+
+## Azure setup
+
+You need two resources (both can live in one Azure AI Foundry project):
+
+### Azure OpenAI (findings extraction + report generation)
+
+1. In [Azure AI Foundry](https://ai.azure.com), deploy a chat model — e.g.
+   `gpt-4.1-mini` or `gpt-4o` for live extraction. Optionally deploy a larger
+   model for report generation.
+2. Note the resource **endpoint** (`https://<resource>.openai.azure.com`), the
+   **deployment name(s)**, and a **key**.
+3. In AAR Studio, open **⚙ Settings**, fill them in, and click
+   **Test connection**.
+
+Calls go browser → Azure with the `api-key` header; structured outputs
+(`response_format: json_schema, strict`) are used when the api-version/model
+supports them, with automatic fallback to `json_object` and then plain-JSON
+parsing. `temperature`/`max_tokens` are never sent, so reasoning models work.
+
+### Azure AI Speech (live audio — Stage 4)
+
+Create a Speech resource (e.g. `australiaeast`), and put its key/region in
+Settings. Language defaults to `en-AU`; diarization is a toggle. The SDK is
+loaded lazily from jsDelivr only when capture starts.
+
+### Key handling — read this
+
+- Keys are stored in **this browser's `localStorage` only** and sent directly
+  to your Azure endpoints. There is no server, proxy, or telemetry.
+- Treat the browser profile as the security boundary: use a dedicated,
+  rotatable key; don't enter keys on shared kiosks; rotate keys after use on
+  borrowed machines. For a shared deployment, put the resources behind your
+  own subscription and hand out scoped keys per facilitator.
+
+## Deployment (Azure Static Web Apps)
+
+1. Create a **Static Web App** (Free tier is fine), deployment source
+   *Other*.
+2. Copy the deployment token (Overview → *Manage deployment token*) into the
+   repo secret `AZURE_STATIC_WEB_APPS_API_TOKEN_AAR_STUDIO`.
+3. Pushes to `main` touching `aar-studio/**` run
+   [`.github/workflows/aar-studio.yml`](../.github/workflows/aar-studio.yml):
+   tests, then an upload of this directory as-is (`skip_app_build: true`).
+
+`staticwebapp.config.json` ships a CSP (self + `cdn.jsdelivr.net` scripts;
+connections limited to Azure OpenAI/Speech domains) and a
+`Permissions-Policy` allowing microphone and display capture for this origin
+only.
+
+## Repository layout
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the module map and data
+model, and [`docs/PLAN.md`](docs/PLAN.md) for the staged roadmap.

--- a/aar-studio/README.md
+++ b/aar-studio/README.md
@@ -9,9 +9,9 @@ Speech-to-text and AI analysis call your own Azure resources directly from the
 browser; nothing leaves the machine except those calls, and all session data
 lives in `localStorage`.
 
-> Status: Stages 1–2 and 4 complete (setup, live listen with real-time
+> Status: Stages 1–4 complete — setup, live listen with real-time
 > transcription, transcript paste ingest, AI extraction, live board, review,
-> report editing + exports). AI report generation is next — see
+> AI report generation and all exports. Stage 5 polish remains — see
 > [`docs/PLAN.md`](docs/PLAN.md).
 
 ## The workflow
@@ -33,10 +33,13 @@ lives in `localStorage`.
    dedupe, manual quick-add, and a fullscreen high-contrast **Present** mode
    for the projector.
 4. **Review** — edit findings and transcript, rename diarised speakers.
-5. **Report** — structured report (headline, context bar, key stats, snapshot,
-   per-phase detail, themes, recommendations, top three actions, assessment),
-   every field editable with live preview. Export a one-page snapshot HTML,
-   Markdown summary, session JSON, or print to PDF.
+5. **Report** — AI drafts the structured report from your curated findings
+   (headline, context bar, key stats, snapshot, per-phase detail, themes,
+   recommendations, top three actions, assessment, verification caveat);
+   every field stays editable with live preview. Export a one-page snapshot
+   HTML, a combined HTML report (snapshot + full summary + findings register
+   + optional transcript appendix), Markdown summary, session JSON, or print
+   to PDF.
 
 Load the **Wamboin sample** from the home screen to see a finished session
 without any Azure setup.

--- a/aar-studio/css/app.css
+++ b/aar-studio/css/app.css
@@ -1,0 +1,293 @@
+/* AAR Studio — single stylesheet, no build step.
+   Palette follows the report artwork: ink #15212b, red #c8102e, gold #e8b84b. */
+
+:root {
+  --ink: #15212b;
+  --ink-2: #22313f;
+  --red: #c8102e;
+  --gold: #e8b84b;
+  --good: #1f7a4d;
+  --bg: #f4f6f8;
+  --panel: #ffffff;
+  --line: #dde3e8;
+  --muted: #5a6570;
+  --radius: 8px;
+  --shadow: 0 1px 3px rgb(21 33 43 / 0.12);
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+h1 { font-size: 1.5rem; margin: 0 0 0.6rem; }
+h2 { font-size: 1.05rem; margin: 0 0 0.5rem; }
+.muted { color: var(--muted); font-size: 0.88rem; }
+
+/* ---------- top bar / nav ---------- */
+.topbar {
+  background: var(--ink);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.topbar__brand { display: flex; align-items: baseline; gap: 0.5rem; }
+.topbar__name { font-weight: 700; letter-spacing: 1px; }
+.topbar__session { color: var(--gold); font-size: 0.85rem; }
+.nav { display: flex; align-items: center; gap: 0.25rem; flex-wrap: wrap; }
+.nav__link {
+  color: #cfd8df;
+  text-decoration: none;
+  padding: 0.4rem 0.7rem;
+  border-radius: var(--radius);
+  font-size: 0.92rem;
+}
+.nav__link:hover { background: var(--ink-2); color: #fff; }
+.nav__link--active { background: var(--red); color: #fff; }
+.nav__link--disabled { opacity: 0.35; pointer-events: none; }
+.nav__settings {
+  background: none;
+  border: none;
+  color: #cfd8df;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.3rem 0.5rem;
+}
+.nav__settings:hover { color: #fff; }
+
+/* ---------- layout ---------- */
+.view { max-width: 1200px; margin: 0 auto; padding: 1.2rem 1rem 4rem; }
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+fieldset {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.8rem 1rem 1rem;
+  margin: 0 0 1rem;
+  min-width: 0;
+}
+legend { font-weight: 700; padding: 0 0.4rem; }
+.form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }
+.page-actions { margin-top: 1rem; }
+
+/* ---------- controls ---------- */
+.btn {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.9rem;
+  font-size: 0.92rem;
+  cursor: pointer;
+  color: var(--ink);
+  min-height: 40px;
+}
+.btn:hover:not(:disabled) { border-color: var(--ink); }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.btn--primary { background: var(--red); border-color: var(--red); color: #fff; font-weight: 600; }
+.btn--primary:hover:not(:disabled) { background: #a90d27; }
+.btn--danger { color: var(--red); }
+.btn--danger:hover:not(:disabled) { border-color: var(--red); }
+.btn--small { padding: 0.25rem 0.55rem; min-height: 30px; font-size: 0.82rem; }
+.btn--big { padding: 0.8rem 1.3rem; font-size: 1rem; min-height: 56px; }
+.btn-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-top: 0.6rem; }
+.icon-btn {
+  background: none; border: none; cursor: pointer; color: var(--muted);
+  font-size: 0.95rem; padding: 0.15rem 0.35rem; border-radius: 4px;
+}
+.icon-btn:hover { color: var(--red); background: #f6e8ea; }
+
+input[type="text"], input[type="date"], input[type="password"], select, textarea {
+  font: inherit;
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+}
+select { width: auto; }
+textarea { resize: vertical; }
+input:focus, select:focus, textarea:focus, .btn:focus-visible {
+  outline: 2px solid var(--red);
+  outline-offset: 1px;
+}
+.field { display: block; margin-bottom: 0.7rem; }
+.field__label { display: block; font-size: 0.82rem; font-weight: 600; margin-bottom: 0.2rem; color: var(--ink-2); }
+.field__help { display: block; font-size: 0.78rem; color: var(--muted); margin-top: 0.15rem; }
+.field--check { display: flex; gap: 0.5rem; align-items: center; }
+.field--check input { width: auto; }
+
+/* ---------- tables ---------- */
+.table { width: 100%; border-collapse: collapse; background: var(--panel); }
+.table th { text-align: left; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); padding: 0.4rem 0.5rem; border-bottom: 2px solid var(--line); }
+.table td { padding: 0.4rem 0.5rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+.table__actions { white-space: nowrap; }
+.table__actions .btn { margin-left: 0.3rem; }
+
+/* ---------- home ---------- */
+.hero { background: var(--ink); color: #fff; border-radius: var(--radius); padding: 1.6rem; margin-bottom: 1.4rem; }
+.hero h1 { color: var(--gold); }
+.hero p { max-width: 60ch; color: #c6d0d8; }
+.hero__actions { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-top: 1rem; }
+.hero .btn:not(.btn--primary) { background: var(--ink-2); color: #fff; border-color: var(--ink-2); }
+
+/* ---------- chips / phases ---------- */
+.chip {
+  display: inline-block;
+  font-size: 0.72rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  background: #e8edf1;
+  color: var(--ink-2);
+  border: 1px solid transparent;
+}
+.chip--phase { background: #e8edf1; }
+.chip--ai { background: #fdf3d7; color: #7a5c00; }
+.chip--manual { background: #e2f0e8; color: var(--good); }
+.chip--done { background: #e2f0e8; color: var(--good); }
+.chip--filter { cursor: pointer; font-size: 0.82rem; padding: 0.3rem 0.8rem; min-height: 34px; }
+.chip--filter:hover { border-color: var(--ink); }
+.chip--on { background: var(--ink); color: #fff; }
+.phase-filter { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
+
+.phase-clicker { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.phase-btn {
+  font: inherit;
+  padding: 0.7rem 1.2rem;
+  min-height: 60px; /* projector / touch friendly */
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+  background: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+.phase-btn:hover { border-color: var(--ink); }
+.phase-btn--active { background: var(--red); border-color: var(--red); color: #fff; }
+.phase-editor__row { display: flex; gap: 0.4rem; margin-bottom: 0.4rem; max-width: 420px; }
+
+/* ---------- capture ---------- */
+.paste-box { width: 100%; font-family: ui-monospace, Consolas, monospace; font-size: 0.85rem; }
+.segments { list-style: none; margin: 0; padding: 0; max-height: 420px; overflow-y: auto; }
+.segment { padding: 0.45rem 0.2rem; border-bottom: 1px solid var(--line); }
+.segment__meta { display: flex; gap: 0.5rem; align-items: center; font-size: 0.78rem; color: var(--muted); margin-bottom: 0.15rem; flex-wrap: wrap; }
+.segment__time { font-family: ui-monospace, Consolas, monospace; }
+.segment__speaker { font-weight: 700; color: var(--ink-2); }
+.segment__text { display: block; }
+
+/* ---------- board ---------- */
+.board-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.6rem; }
+.board-toolbar h1 { margin: 0; }
+.quick-add { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.quick-add__input { flex: 1; min-width: 220px; width: auto; }
+.board { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.8rem; align-items: start; }
+.board__col { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+.board__head {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 0.5rem 0.7rem; color: #fff; font-weight: 700; font-size: 0.88rem;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.board__col--happened .board__head { background: var(--ink-2); }
+.board__col--well .board__head { background: var(--good); }
+.board__col--didnt .board__head { background: var(--red); }
+.board__col--next .board__head { background: #b07d10; }
+.board__count { background: rgb(255 255 255 / 0.25); border-radius: 999px; padding: 0 0.55rem; font-size: 0.85rem; }
+.board__cards { padding: 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; min-height: 60px; }
+.board__empty { text-align: center; margin: 0.5rem 0; }
+.finding { border: 1px solid var(--line); border-radius: 6px; padding: 0.5rem 0.6rem; background: #fff; }
+.finding--well { border-left: 4px solid var(--good); }
+.finding--didnt { border-left: 4px solid var(--red); }
+.finding--happened { border-left: 4px solid var(--ink-2); }
+.finding--next { border-left: 4px solid #b07d10; }
+.finding__meta { display: flex; gap: 0.4rem; align-items: center; margin-top: 0.35rem; flex-wrap: wrap; }
+.finding__tools { margin-left: auto; white-space: nowrap; }
+.finding__quote { font-size: 0.78rem; color: var(--muted); font-style: italic; margin-top: 0.3rem; }
+.finding__editor textarea { margin-bottom: 0.3rem; }
+
+/* ---------- present mode ---------- */
+.present-exit { display: none; }
+body.present { background: var(--ink); }
+body.present .topbar,
+body.present .board-toolbar,
+body.present .quick-add,
+body.present .phase-filter { display: none; }
+body.present .view { max-width: none; padding: 1.2rem 1.5rem; }
+body.present .present-exit {
+  display: block; position: fixed; bottom: 0.8rem; right: 0.8rem; opacity: 0.25; z-index: 20;
+}
+body.present .present-exit:hover { opacity: 1; }
+body.present .board { gap: 1rem; }
+body.present .board__col { background: var(--ink-2); border-color: #364655; }
+body.present .board__head { font-size: 1.25rem; padding: 0.8rem 1rem; }
+body.present .finding { background: #0d141b; border-color: #364655; color: #f2f5f7; font-size: 1.35rem; line-height: 1.35; }
+body.present .finding__quote { color: #93a1ad; font-size: 0.95rem; }
+body.present .finding__tools { display: none; }
+body.present .chip--phase { background: var(--gold); color: var(--ink); font-size: 0.85rem; font-weight: 700; }
+body.present .chip--ai, body.present .chip--manual { display: none; }
+body.present .board__empty { color: #93a1ad; }
+
+/* ---------- review ---------- */
+.review-segments, .review-findings { display: flex; flex-direction: column; gap: 0.6rem; max-height: 70vh; overflow-y: auto; }
+.review-segment, .review-finding { border: 1px solid var(--line); border-radius: 6px; padding: 0.5rem; background: #fff; }
+.review-segment__meta, .review-finding__meta { display: flex; gap: 0.4rem; align-items: center; margin-bottom: 0.3rem; flex-wrap: wrap; }
+.review-segment__speaker { max-width: 200px; }
+.review-finding--well { border-left: 4px solid var(--good); }
+.review-finding--didnt { border-left: 4px solid var(--red); }
+.review-finding--happened { border-left: 4px solid var(--ink-2); }
+.review-finding--next { border-left: 4px solid #b07d10; }
+.review-finding__quote { margin-top: 0.3rem; font-style: italic; }
+
+/* ---------- report ---------- */
+.report-layout { display: grid; grid-template-columns: minmax(340px, 1fr) minmax(380px, 1.1fr); gap: 1rem; align-items: start; }
+@media (max-width: 980px) { .report-layout { grid-template-columns: 1fr; } }
+.report-form { min-width: 0; }
+.report-preview-pane { position: sticky; top: 4rem; }
+.report-preview { width: 100%; height: 75vh; border: 1px solid var(--line); border-radius: var(--radius); background: #fff; }
+.theme-row { display: grid; grid-template-columns: 1fr auto; gap: 0.4rem; margin-bottom: 0.6rem; }
+.theme-row textarea { grid-column: 1 / -1; }
+.phase-report { border: 1px solid var(--line); border-radius: 6px; padding: 0.5rem 0.8rem; margin-bottom: 0.6rem; background: #fff; }
+.phase-report summary { font-weight: 700; cursor: pointer; }
+
+/* ---------- dialog / settings ---------- */
+.dialog { border: none; border-radius: var(--radius); box-shadow: 0 10px 40px rgb(0 0 0 / 0.3); padding: 1.2rem 1.4rem; width: min(560px, 92vw); }
+.dialog::backdrop { background: rgb(21 33 43 / 0.6); }
+.dialog h3 { margin: 1rem 0 0.5rem; }
+.dialog__actions { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 1rem; }
+.settings__note { font-size: 0.85rem; color: var(--muted); }
+.settings__row { display: flex; gap: 0.6rem; align-items: center; margin: 0.4rem 0 0.2rem; }
+.settings__status { font-size: 0.85rem; flex: 1; }
+.settings__status--ok { color: var(--good); }
+.settings__status--err { color: var(--red); }
+
+/* ---------- toasts ---------- */
+.toast-host { position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%); display: flex; flex-direction: column; gap: 0.4rem; z-index: 100; }
+.toast {
+  background: var(--ink); color: #fff; padding: 0.6rem 1rem; border-radius: var(--radius);
+  box-shadow: var(--shadow); font-size: 0.9rem; max-width: 80vw;
+  animation: toast-in 0.25s ease-out;
+}
+.toast--error { background: var(--red); }
+.toast--out { opacity: 0; transition: opacity 0.4s; }
+@keyframes toast-in { from { opacity: 0; transform: translateY(8px); } }
+
+@media print {
+  .topbar, .board-toolbar, .quick-add, .phase-filter, .toast-host { display: none; }
+}

--- a/aar-studio/css/app.css
+++ b/aar-studio/css/app.css
@@ -193,6 +193,30 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible {
 .segment__speaker { font-weight: 700; color: var(--ink-2); }
 .segment__text { display: block; }
 
+/* ---------- live listen ---------- */
+.live__row { display: flex; gap: 0.8rem; align-items: center; flex-wrap: wrap; }
+.live__dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--red);
+  animation: live-pulse 1.6s ease-in-out infinite;
+}
+@keyframes live-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.25; } }
+.live__state { font-weight: 700; }
+.live__elapsed { font-family: ui-monospace, Consolas, monospace; color: var(--muted); }
+.meter {
+  flex: 1; min-width: 120px; max-width: 320px; height: 12px;
+  background: #e8edf1; border-radius: 999px; overflow: hidden;
+}
+.meter__bar {
+  --level: 0;
+  height: 100%; width: calc(var(--level) * 100%);
+  background: linear-gradient(90deg, var(--good), var(--gold) 70%, var(--red));
+  transition: width 80ms linear;
+}
+.live__interim { min-height: 1.5em; margin-top: 0.6rem; color: var(--muted); font-style: italic; }
+.live__error { color: var(--red); font-weight: 600; }
+@media (prefers-reduced-motion: reduce) { .live__dot { animation: none; } }
+
 /* ---------- board ---------- */
 .board-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.6rem; }
 .board-toolbar h1 { margin: 0; }

--- a/aar-studio/data/sample-session.json
+++ b/aar-studio/data/sample-session.json
@@ -1,0 +1,150 @@
+{
+  "id": "sample-wamboin-2026",
+  "schemaVersion": 1,
+  "createdAt": "2026-06-12T09:05:00.000Z",
+  "updatedAt": "2026-06-12T10:02:00.000Z",
+  "incident": {
+    "title": "Wamboin Structure Fire — 412 Macs Reef Road",
+    "date": "2026-06-06",
+    "location": "412 Macs Reef Road, Wamboin NSW",
+    "type": "Structure Fire"
+  },
+  "aar": {
+    "date": "2026-06-12",
+    "location": "Bungendore Station",
+    "facilitator": "Duty Officer (unclear)"
+  },
+  "units": [
+    { "unit": "Wamboin", "role": "First on scene — pump, initial attack" },
+    { "unit": "Jerrabomberra Creek", "role": "Relief truck — overnight overhaul & watching" },
+    { "unit": "Queanbeyan / Ridgeway / Bungendore", "role": "BA crews, suppression, water shuttle" },
+    { "unit": "Support Brigade", "role": "Logistics — BA cylinder resupply" },
+    { "unit": "Fire & Rescue NSW", "role": "Two appliances; interior crews under RFS control" },
+    { "unit": "Police / Essential Energy / FI", "role": "Scene control, power isolation, investigation" }
+  ],
+  "phases": ["Arrival", "Rescue", "Suppression", "Overhaul"],
+  "currentPhase": "Overhaul",
+  "speakers": {
+    "Speaker 1": "Facilitator",
+    "Speaker 2": "Wamboin captain",
+    "Speaker 3": "Pump operator",
+    "Speaker 4": "BACO"
+  },
+  "segments": [
+    { "id": "seg-001", "t": 95, "speaker": "Speaker 1", "text": "Alright, let's start with arrival. Page went out cleanly, we required one and four and had two and six on the initial response plus the two FRNSW trucks — eight appliances all up.", "phase": "Arrival", "source": "paste", "analysed": true },
+    { "id": "seg-002", "t": 210, "speaker": "Speaker 2", "text": "Coming up the driveway it's about two hundred metres, narrow, and the ground falls away maybe a metre and a half on the Delta side. The overhead imagery we had just doesn't show the topography at all.", "phase": "Arrival", "source": "paste", "analysed": true },
+    { "id": "seg-003", "t": 412, "speaker": "Speaker 3", "text": "Honest call from me — I set the pump up about ten metres from the smoke. I was masked up the whole night and we couldn't flake hose without walking into it. We should have set up further back, you can always move up.", "phase": "Arrival", "source": "paste", "analysed": true },
+    { "id": "seg-004", "t": 760, "speaker": "Speaker 2", "text": "We couldn't do a proper 360 to start with — cars and rubbish blocked the back. It was about thirty minutes in before a spare BA crew got around, and they moved two G-size argon bottles and an LPG off the wall.", "phase": "Rescue", "source": "paste", "analysed": true },
+    { "id": "seg-005", "t": 1290, "speaker": "Speaker 2", "text": "A single thirty-eight had basically no effect. Once we got the ground monitor going at eight hundred litres a minute in that Z pattern it knocked it down and we actually conserved water doing it.", "phase": "Suppression", "source": "paste", "analysed": true },
+    { "id": "seg-006", "t": 1505, "speaker": "Speaker 3", "text": "When the tanks ran dry we dumped the three Cat 1s to go hunting for dams in the dark, and for ten or twenty minutes we were back to one crew on a single thirty-eight. We should just call more tankers up front next time.", "phase": "Suppression", "source": "paste", "analysed": true },
+    { "id": "seg-007", "t": 1820, "speaker": "Speaker 4", "text": "We went straight to a Stage 2 board, set a two-cylinder limit per operator and pooled every three hundred bar cylinder from every truck at staging. At peak we had about ten operators with eight committed.", "phase": "Suppression", "source": "paste", "analysed": true },
+    { "id": "seg-008", "t": 2400, "speaker": "Speaker 2", "text": "The relief brigade was never actually paged — it all went through the group chat, so most of their members never knew the job was on. If you want a truck, page it through dispatch.", "phase": "Overhaul", "source": "paste", "analysed": true },
+    { "id": "seg-009", "t": 2710, "speaker": "Speaker 1", "text": "And the reignition about ten the next morning — the crew worked with the fire investigator, cut and peeled the sheeting back in daylight. TIC from outside only read twelve to fifteen degrees even with deep-seated heat in the middle.", "phase": "Overhaul", "source": "paste", "analysed": true }
+  ],
+  "findings": [
+    { "id": "f-001", "category": "well", "phase": "Arrival", "text": "Dispatch and turnout worked: the page went out cleanly and the operator quota was comfortably exceeded (required 1+4, had 2+6 plus FRNSW on the initial response).", "quote": "we required one and four and had two and six on the initial response", "segmentIds": ["seg-001"], "source": "ai", "createdAt": "2026-06-12T09:10:00.000Z" },
+    { "id": "f-002", "category": "happened", "phase": "Arrival", "text": "Access was via a ~200 m narrow driveway with a sharp drop-off on the Delta side; overhead imagery used for planning did not convey the steep topography.", "quote": "the overhead imagery we had just doesn't show the topography at all", "segmentIds": ["seg-002"], "source": "ai", "createdAt": "2026-06-12T09:10:00.000Z" },
+    { "id": "f-003", "category": "didnt", "phase": "Arrival", "text": "The pump was set up roughly 10 m from thick smoke: the operator worked masked in the hot zone all night and hose could not be flaked without entering smoke.", "quote": "I set the pump up about ten metres from the smoke", "segmentIds": ["seg-003"], "source": "ai", "createdAt": "2026-06-12T09:11:00.000Z" },
+    { "id": "f-004", "category": "next", "phase": "Arrival", "text": "Err further back when positioning the pump and attack appliances — moving up later is easy, pulling back out of the hot zone is not.", "quote": "We should have set up further back, you can always move up", "segmentIds": ["seg-003"], "source": "ai", "createdAt": "2026-06-12T09:11:00.000Z" },
+    { "id": "f-005", "category": "happened", "phase": "Rescue", "text": "An initial 360 was not feasible — terrain, stored cars and rubbish blocked the rear. The full 360 was completed about 30 minutes in by a spare BA crew.", "quote": "It was about thirty minutes in before a spare BA crew got around", "segmentIds": ["seg-004"], "source": "ai", "createdAt": "2026-06-12T09:12:00.000Z" },
+    { "id": "f-006", "category": "next", "phase": "Rescue", "text": "Where the initial 360 is impossible, explicitly task the first spare BA crew to complete it — on this job it found and relocated gas cylinders against the shed wall.", "quote": "they moved two G-size argon bottles and an LPG off the wall", "segmentIds": ["seg-004"], "source": "ai", "createdAt": "2026-06-12T09:12:00.000Z" },
+    { "id": "f-007", "category": "well", "phase": "Suppression", "text": "The ground monitor was the right call: 800 L/min worked in a Z-pattern knocked the fire down decisively and conserved water where single 38 mm lines had no effect.", "quote": "the ground monitor going at eight hundred litres a minute in that Z pattern", "segmentIds": ["seg-005"], "source": "ai", "createdAt": "2026-06-12T09:13:00.000Z" },
+    { "id": "f-008", "category": "didnt", "phase": "Suppression", "text": "With tanks dry, the three Cat 1s were dispersed to hunt water in the dark, scaling operations back to a single crew on one 38 mm for 10–20 minutes.", "quote": "for ten or twenty minutes we were back to one crew on a single thirty-eight", "segmentIds": ["seg-006"], "source": "ai", "createdAt": "2026-06-12T09:13:00.000Z" },
+    { "id": "f-009", "category": "next", "phase": "Suppression", "text": "For a going structure fire off reticulated water, call for more tankers up front (the comparable job used 8 Cat 1s) and run 65 mm to staging with trucks rotating through.", "quote": "We should just call more tankers up front next time", "segmentIds": ["seg-006"], "source": "ai", "createdAt": "2026-06-12T09:13:00.000Z" },
+    { "id": "f-010", "category": "well", "phase": "Suppression", "text": "BA management was strong: straight to a Stage 2 board, a two-cylinder-per-operator limit, and every 300-bar cylinder on the fireground pooled at staging — about 10 operators at peak.", "quote": "straight to a Stage 2 board, set a two-cylinder limit per operator", "segmentIds": ["seg-007"], "source": "ai", "createdAt": "2026-06-12T09:14:00.000Z" },
+    { "id": "f-011", "category": "well", "phase": "Suppression", "text": "The BACO performance was singled out as outstanding — constant comms, intensity confirmations and a full picture of who was where.", "quote": "(unclear) the best BACO they'd worked with", "segmentIds": [], "source": "manual", "createdAt": "2026-06-12T09:20:00.000Z" },
+    { "id": "f-012", "category": "didnt", "phase": "Suppression", "text": "Foam was probably warranted for a fuel-laden shed (racing fuel and metho in the rear dyno room) but was not used.", "quote": "", "segmentIds": [], "source": "manual", "createdAt": "2026-06-12T09:21:00.000Z" },
+    { "id": "f-013", "category": "didnt", "phase": "Overhaul", "text": "The relief brigade was tasked via group chat instead of a formal page, so most of its members never knew the job was happening.", "quote": "If you want a truck, page it through dispatch", "segmentIds": ["seg-008"], "source": "ai", "createdAt": "2026-06-12T09:15:00.000Z" },
+    { "id": "f-014", "category": "next", "phase": "Overhaul", "text": "Use formal paging via dispatch for any truck or relief tasking; SCC can tailor the page to exactly what is needed. Reserve group chats for individual availability.", "quote": "page it through dispatch", "segmentIds": ["seg-008"], "source": "ai", "createdAt": "2026-06-12T09:15:00.000Z" },
+    { "id": "f-015", "category": "happened", "phase": "Overhaul", "text": "Reignition at ~1000 the next morning was worked directly with the fire investigator; TIC readings from outside were only 12–15° despite known deep-seated heat — exterior TIC will not find buried hot spots.", "quote": "TIC from outside only read twelve to fifteen degrees", "segmentIds": ["seg-009"], "source": "ai", "createdAt": "2026-06-12T09:16:00.000Z" },
+    { "id": "f-016", "category": "didnt", "phase": "General", "text": "The BA cylinder refurbishment program plus the long weekend left no refill capacity until Tuesday — pre-notice logistics on any confirmed structure fire.", "quote": "", "segmentIds": [], "source": "manual", "createdAt": "2026-06-12T09:22:00.000Z" }
+  ],
+  "report": {
+    "headline": "Wamboin Structure Fire — 412 Macs Reef Road",
+    "contextBar": "The property: rural block up a medium–long driveway (~200 m) · steep terrain, sharp drop-off on the western side · tight access, no vehicle route to the rear · no mains water · shed uphill of the house, trees within 0.5 m",
+    "stats": [
+      { "value": "8", "label": "Appliances on initial dispatch" },
+      { "value": "10", "label": "BA operators at peak" },
+      { "value": "800", "label": "L/min ground monitor — decisive" },
+      { "value": "30", "label": "Min before 360° was possible" },
+      { "value": "~1000", "label": "Reignition next morning" },
+      { "value": "0", "label": "Injuries" }
+    ],
+    "snapshot": [
+      "Fully involved two-bay × four-bay shed: cars, gas cylinders, and an unknown rear dyno room holding racing fuel and metho. Centre roof collapse and multiple explosions during initial attack. Single 38 mm lines had no effect; the ground monitor knocked it down. With no reticulated water, three Cat 1s shuttled supply until a dam on the neighbouring property turned the fight. Declared a crime scene; overnight watch held; one reignition extinguished with the fire investigator next morning."
+    ],
+    "phases": [
+      {
+        "name": "Arrival",
+        "happened": "Night-time page on a long weekend; six RFS appliances plus two FRNSW trucks on initial dispatch. Long, narrow driveway with difficult topography; staging at the gate with three appliances at the head at any one time.",
+        "well": [
+          "Clean dispatch and arrival. Operator quota exceeded; specific resource request (\"4 BA operators + driver\"); tight driveway staging flowed straight into attack."
+        ],
+        "didnt": [
+          "Working room is the #1 lesson. Pump set up ~10 m from thick smoke; hose couldn't be flaked without entering it; operator masked all night. Set up further back — moving up is easy, pulling back isn't."
+        ]
+      },
+      {
+        "name": "Rescue",
+        "happened": "Effectively a nil rescue phase — crews worked on confirmed advice of nobody inside. The initial 360 was blocked by terrain and stored cars; a spare BA crew completed it ~30 minutes in and relocated gas cylinders from the shed wall.",
+        "well": [
+          "Good intelligence at the gate. Occupants confirmed accounted for and power isolated before crews committed up the driveway."
+        ],
+        "didnt": [
+          "Task the 360 explicitly. Where terrain prevents an initial 360, task the first spare BA crew to complete it — it found hazards and changed the picture."
+        ]
+      },
+      {
+        "name": "Suppression",
+        "happened": "Single 38 mm lines had negligible effect; the ground monitor at 800 L/min in a Z-pattern knocked the fire down. An improvised relay (pumper fed by Cat 6, three Cat 1s shuttling) held until the neighbouring dam turned the corner.",
+        "well": [
+          "Right tool, fast. Monitor at 800 L/min in a Z-pattern conserved water and knocked the fire down where 38s could not.",
+          "Strong BA control. Straight to Stage 2 board; two-cylinder limit; every 300-bar cylinder pooled at staging; standout BACO performance.",
+          "Interagency cooperation. FRNSW interior crews worked under RFS operations without friction; Essential Energy isolated power."
+        ],
+        "didnt": [
+          "Call water early. Hunting dams in the dark cost a 10–20 min scale-back. Roll more tankers up front, run 65 mm to staging and rotate trucks; bulk water and ACT support exist — but you must ask.",
+          "Match the relay to the supply. Closed relay needs continuous water; intermittent shuttle = open relay and keep the tank topped.",
+          "Foam was probably warranted for a fuel-laden shed — not used.",
+          "Own the cordon. Civilians played police and RFS off against each other — brief police directly and early."
+        ]
+      },
+      {
+        "name": "Overhaul",
+        "happened": "Containment declared deliberately — confirmed face-to-face with crews, then formally reported. Crime-scene constraints shaped overhaul; an overnight watch was held and a reignition at ~1000 was worked with the fire investigator in daylight.",
+        "well": [
+          "Deliberate containment call — confirmed face-to-face with crews before reporting, then a quick shift to overhaul under crime-scene constraints."
+        ],
+        "didnt": [
+          "Page, don't message. Relief brigade tasked by group chat — most members never knew. SCC can tailor the page to exactly what's needed.",
+          "Exterior TIC won't find buried hot spots. Readings of 12–15° outside despite deep-seated heat in the middle; crews correctly declined to enter under the collapsed roof."
+        ]
+      }
+    ],
+    "themes": [
+      {
+        "title": "Logistics and readiness aftermath",
+        "body": "The BA cylinder refurbishment program left the district thin on spares, and FRNSW could not refill cylinders over the long weekend — capacity was not restored until Tuesday. Pre-notice refill and logistics as soon as a structure fire is confirmed, and assume a confirmed fire triggers roughly 8 operators plus logistics immediately."
+      }
+    ],
+    "recommendations": [
+      "Positioning and working room — set the pump and primary attack appliances further back from the structure on arrival, with room to flake hose, stage BA and run decon clear of the hot zone.",
+      "Water strategy for non-reticulated structure fires: request 6–8 Cat 1s at confirmation; run 65 mm to staging and rotate trucks; consider bulk water and ACT resources early.",
+      "Relay doctrine: dual 65 mm closed relay where supply is continuous; open relay with tank top-up where supply is intermittent. Cover at a training night.",
+      "Trigger logistics early: BA support, spare cylinders and refill pre-notice on confirmation of a working structure fire.",
+      "Consider early foam application for sheds/workshops where fuel loads are likely.",
+      "Formal paging for truck/brigade taskings, with SCC tailoring the paged requirement; group chats for individual availability only.",
+      "Review spare cylinder holdings during refurbishment programs; establish an after-hours refill arrangement with FRNSW.",
+      "Brief police directly and early on civilian exclusion and who authorises scene access.",
+      "Task the first spare BA crew to complete the 360 where terrain prevents it initially.",
+      "Duty officer and captain to review the fire investigation engagement/sequencing issues offline."
+    ],
+    "actions": [
+      "Position for working room: set the pump and attack appliances further back from the structure on arrival, with space to flake hose, stage BA and run decon clear of the hot zone.",
+      "Pre-roll water, BA support and logistics the moment a working structure fire is confirmed — multiple Triple Zero calls means it's real.",
+      "Formal paging via dispatch for any truck or relief tasking — group chats are for individual availability only."
+    ],
+    "assessment": "A hot, fast-moving job — described as the most intense the brigades had run in a long time without hydrant backup — handled well. Nobody was hurt, the fire never threatened the house or bush despite trees within half a metre of the shed, and the crews adapted intelligently to water and cylinder constraints. The single most important lesson is positioning: establish enough working room between truck and fire from the outset.",
+    "caveat": "Compiled from the AAR meeting transcript (single-mic recording) and whiteboard notes — verify figures and callsigns before district distribution. Full detail in the accompanying AAR summary document."
+  }
+}

--- a/aar-studio/docs/ARCHITECTURE.md
+++ b/aar-studio/docs/ARCHITECTURE.md
@@ -108,7 +108,7 @@ since the last pass **and** ≥70 new words are pending, plus immediately on
 phase change and on demand. (Wired to the manual Analyse button until Stage 4
 adds live audio.)
 
-## Audio pipeline (Stage 4 — designed, not yet built)
+## Audio pipeline (live listen)
 
 ```
 mic (getUserMedia) ─┐
@@ -120,9 +120,19 @@ uploaded file ─► decodeAudioData ─► buffer source ──────┘ 
                                                                  └─► MediaRecorder (optional local backup)
 ```
 
-Speech: `microsoft-cognitiveservices-speech-sdk` from jsDelivr, lazy `import()`,
-`ConversationTranscriber` (diarization toggle) with `en-AU` default. All three
-sources feed the same push stream, so transcription code has one input path.
+Speech: `microsoft-cognitiveservices-speech-sdk` from jsDelivr, lazily
+injected on first use, `ConversationTranscriber` (diarization toggle, plain
+`SpeechRecognizer` when off) with `en-AU` default. All three sources feed the
+same push stream, so transcription code has one input path.
+
+Modules: `js/audio/worklet.js` (AudioWorklet PCM tap), `js/audio/speech.js`
+(SDK loader + transcriber wrapper), `js/audio/live.js` (singleton controller —
+survives view re-renders; final results become session segments tagged with
+the current phase; segment timestamps come from the recogniser offset).
+`js/analyse.js` owns the shared extraction runner and the live trigger
+counters; the controller polls `maybeAutoExtract()` every 5 s and runs a final
+pass on stop. Pure helpers (resampling, RMS, speaker labels) live in
+`js/lib/audioUtils.js` under test.
 
 ## Security / deployment
 

--- a/aar-studio/docs/ARCHITECTURE.md
+++ b/aar-studio/docs/ARCHITECTURE.md
@@ -1,0 +1,140 @@
+# AAR Studio — Architecture
+
+Static web app. No build step, no backend, no dependencies at runtime other
+than CDN-loaded Azure SDKs (lazy). Everything below is plain ES modules served
+as-is.
+
+## Module map
+
+```
+aar-studio/
+├── index.html                  # shell: nav, view container, settings <dialog>
+├── css/app.css                 # theme (CSS vars), board, present mode, print
+├── js/
+│   ├── main.js                 # boot, hash router, nav state, re-render policy
+│   ├── store.js                # current session + localStorage persistence, pub/sub
+│   ├── settings.js             # Azure config (localStorage), settings dialog, test connection
+│   ├── ui.js                   # DOM helpers (h, toasts, download, dialogs) — browser only
+│   ├── views/
+│   │   ├── home.js             # session list, new/import/sample
+│   │   ├── setup.js            # incident/AAR/units/phases form
+│   │   ├── capture.js          # phase clicker, paste-transcript ingest, segments, analyse
+│   │   ├── board.js            # live findings board + Present mode + quick add
+│   │   ├── review.js           # transcript + speaker + findings editing
+│   │   └── report.js           # report editor, live preview, exports
+│   └── lib/                    # PURE modules — no DOM, covered by node --test
+│       ├── model.js            # session/finding/segment factories, categories, validation
+│       ├── text.js             # escapeHtml, word counts, slugs, time formatting
+│       ├── transcriptParser.js # Teams DOCX paste / "Name: text" / WEBVTT / plain
+│       ├── dedupe.js           # near-duplicate finding detection
+│       ├── llm.js              # Azure OpenAI chat completions + fallback chain
+│       ├── extraction.js       # prompts, schema, chunking, trigger policy
+│       └── exports.js          # snapshot HTML, Markdown summary, report template
+├── data/sample-session.json    # Wamboin structure fire example session
+├── test/                       # node:test suites for js/lib (zero deps)
+├── staticwebapp.config.json    # CSP, Permissions-Policy, SPA fallback
+├── package.json                # {"type":"module"} + npm test (node --test)
+└── docs/ (PLAN.md, ARCHITECTURE.md)
+```
+
+Views import `store` + `lib`; `lib` never imports views or `ui.js`. `llm.js`
+uses only `fetch`, so it is loadable under node for tests.
+
+## Data model (schemaVersion 1)
+
+```jsonc
+{
+  "id": "uuid", "schemaVersion": 1,
+  "createdAt": "ISO", "updatedAt": "ISO",
+  "incident": { "title": "", "date": "", "location": "", "type": "" },
+  "aar": { "date": "", "location": "", "facilitator": "" },
+  "units": [ { "unit": "", "role": "" } ],
+  "phases": ["Arrival", "Rescue", "Suppression", "Overhaul"], // General is implicit
+  "currentPhase": "General",          // live phase clicker state
+  "segments": [ {
+    "id": "uuid", "t": 125,            // seconds from start, or null
+    "speaker": "Speaker 1",            // raw (diarised) name; display via speakers map
+    "text": "", "phase": "Arrival",
+    "source": "live" | "paste" | "file",
+    "analysed": false                   // consumed by an extraction pass
+  } ],
+  "findings": [ {
+    "id": "uuid",
+    "category": "happened" | "well" | "didnt" | "next",
+    "phase": "Suppression",            // any session phase or "General"
+    "text": "", "quote": "",          // short verbatim quote
+    "segmentIds": ["..."],
+    "source": "ai" | "manual",
+    "createdAt": "ISO"
+  } ],
+  "speakers": { "Speaker 1": "Dave (Wamboin captain)" },  // rename map
+  "report": null | { /* see exports.js emptyReport() */ }
+}
+```
+
+Persistence: `localStorage["aarstudio.session.<id>"]` per session (autosaved
+on every mutation), `aarstudio.settings` for Azure config, `aarstudio.lastSession`
+for resume. Import/export is the same JSON via `model.normaliseSession()`.
+
+## LLM integration (Azure OpenAI on Azure AI Foundry)
+
+`POST {endpoint}/openai/deployments/{deployment}/chat/completions?api-version=...`
+with `api-key` header, browser → Azure directly.
+
+- Attempt 1: `response_format: { type: "json_schema", json_schema: { strict: true, … } }`
+- On HTTP 400 (unsupported): retry with `{ type: "json_object" }`
+- On a second 400: retry with no response_format and parse the first JSON
+  object out of the reply (``` fences tolerated).
+- `temperature`/`max_tokens` are never sent (reasoning-model compatibility).
+- Errors map to actionable hints: network/`TypeError` → CORS + endpoint hint;
+  401/403 → key; 404 → deployment name / api-version; 429 → rate limit.
+
+Two deployments are configurable: a fast one for live extraction (e.g.
+`gpt-4.1-mini`/`gpt-4o`) and an optional larger one for report generation.
+
+### Extraction
+
+Segments are chunked (~450 words, consecutive, phase boundaries respected) and
+each chunk sent with: session context (incident, units, phases), the four
+category definitions, and prompt rules — fix obvious single-mic mis-hearings
+from context, mark uncertain names/figures "(unclear)", keep Australian fire
+service terminology (BA, BACO, Cat 1, 38/65 mm, OCC, FRNSW, appliance), skip
+small talk and facilitation chatter, every finding carries a short verbatim
+quote and its source segment ids. Returned findings pass through
+`dedupe.dedupeFindings()` before being added to the board.
+
+Live trigger policy (`extraction.shouldAutoExtract`): run when ≥45 s elapsed
+since the last pass **and** ≥70 new words are pending, plus immediately on
+phase change and on demand. (Wired to the manual Analyse button until Stage 4
+adds live audio.)
+
+## Audio pipeline (Stage 4 — designed, not yet built)
+
+```
+mic (getUserMedia) ─┐
+tab/system audio    ├─► MediaStream ─► AudioContext ─► AudioWorklet tap
+(getDisplayMedia) ──┘                                   │        │
+uploaded file ─► decodeAudioData ─► buffer source ──────┘        ├─► RMS level meter
+                                                                 ├─► resample → 16 kHz mono PCM16
+                                                                 │     └─► Speech SDK push stream
+                                                                 └─► MediaRecorder (optional local backup)
+```
+
+Speech: `microsoft-cognitiveservices-speech-sdk` from jsDelivr, lazy `import()`,
+`ConversationTranscriber` (diarization toggle) with `en-AU` default. All three
+sources feed the same push stream, so transcription code has one input path.
+
+## Security / deployment
+
+- Azure Static Web Apps; `staticwebapp.config.json` sets CSP
+  (`script-src 'self' cdn.jsdelivr.net blob:`; `connect-src` limited to
+  `*.openai.azure.com`, `*.cognitiveservices.azure.com`,
+  `*.services.ai.azure.com`, `*.api.cognitive.microsoft.com`,
+  `wss://*.stt.speech.microsoft.com`; `style-src 'self' 'unsafe-inline'`) and
+  `Permissions-Policy: microphone=(self), display-capture=(self)`.
+- Keys are entered by the operator and stay in `localStorage`; nothing is
+  proxied or logged server-side because there is no server. Use scoped,
+  rotatable keys; see README for the trade-offs.
+- GitHub Actions workflow `.github/workflows/aar-studio.yml`: node tests on
+  PR/push touching `aar-studio/**`, SWA deploy from `main`
+  (`skip_app_build: true`).

--- a/aar-studio/docs/PLAN.md
+++ b/aar-studio/docs/PLAN.md
@@ -1,7 +1,7 @@
 # AAR Studio — Plan
 
 **Status:** Living document — update when scope or priorities change.
-**Last updated:** June 2026 (Stages 1–2 and 4 delivered, Stage 3 partially delivered)
+**Last updated:** June 2026 (Stages 1–4 delivered; Stage 5 polish remaining)
 
 ## Vision
 
@@ -79,23 +79,23 @@ Azure Static Web Apps.
 - Review view: edit/recategorise/rephase/delete findings; edit segment text,
   phase and speaker; rename diarised speakers (map applied everywhere).
 
-### Stage 3 — Report studio 🔶 (editing + exports delivered; AI generation next)
+### Stage 3 — Report studio ✅ (delivered)
 
-Delivered:
 - Report data model `{headline, contextBar, stats[], snapshot[], phases[],
   themes[], recommendations[], actions[3], assessment, caveat}`; blank
   template creation pre-filled from session metadata.
+- **AI report generation** from the curated findings (`lib/reportGen.js`):
+  strict JSON schema aligned to the session's phases, style rules matching
+  the snapshot artwork ("Bold lead. Detail." bullets, Australian fire-service
+  terminology, no invented facts, "(unclear)" markers preserved); uses the
+  optional report deployment with fallback to the chat deployment;
+  regenerate-with-confirm once a report exists.
 - Report editor with live preview (iframe), every field editable.
 - Exports: one-page executive snapshot HTML (dark header, red context bar,
   stats row, who attended, What worked / Lessons columns, Top three actions
-  footer), Markdown summary + findings register, JSON session export,
-  print-to-PDF via the preview.
-
-Remaining:
-- **AI report generation** from the curated findings + transcript (separate
-  optional report deployment, e.g. a larger model than the live-extraction one).
-- **Combined HTML report** export (snapshot page + full summary + findings
-  register + optional transcript appendix in one file).
+  footer), **combined HTML report** (snapshot page + full summary + findings
+  register + optional transcript appendix, print-paginated), Markdown summary
+  + findings register, JSON session export, print-to-PDF via the preview.
 
 ### Stage 4 — Live audio capture ✅ (delivered)
 

--- a/aar-studio/docs/PLAN.md
+++ b/aar-studio/docs/PLAN.md
@@ -1,7 +1,7 @@
 # AAR Studio — Plan
 
 **Status:** Living document — update when scope or priorities change.
-**Last updated:** June 2026 (initial version, Stages 1–2 delivered, Stage 3 partially delivered)
+**Last updated:** June 2026 (Stages 1–2 and 4 delivered, Stage 3 partially delivered)
 
 ## Vision
 
@@ -97,18 +97,22 @@ Remaining:
 - **Combined HTML report** export (snapshot page + full summary + findings
   register + optional transcript appendix in one file).
 
-### Stage 4 — Live audio capture ⬜
+### Stage 4 — Live audio capture ✅ (delivered)
 
 - One shared audio pipeline: source (mic `getUserMedia` / tab or system audio
   `getDisplayMedia` / decoded uploaded file) → `AudioWorklet` tap → resample →
   16 kHz mono PCM16 → Azure Speech **push stream**; RMS level meter from the
   same tap.
 - Azure AI Speech JS SDK (`microsoft-cognitiveservices-speech-sdk` from
-  jsDelivr, lazy-loaded), `ConversationTranscriber` with diarization toggle,
-  en-AU default; live interim results in the Capture view.
-- Optional local `MediaRecorder` backup recording offered as a download.
-- Phase clicker tags live segments; auto-extraction loop using the Stage 2
-  trigger policy (45 s / 70 words / phase change / on demand).
+  jsDelivr, lazy-loaded on first use), `ConversationTranscriber` with the
+  diarization toggle (plain `SpeechRecognizer` when off), en-AU default; live
+  interim results and elapsed/level display in the Capture view; diarised ids
+  mapped to stable "Speaker N" labels (renameable in Review).
+- Optional local `MediaRecorder` backup recording (mic/tab sources) offered
+  as a download after stop.
+- Phase clicker tags live segments; auto-extraction loop runs the Stage 2
+  trigger policy (45 s / 70 words, plus phase change / on demand / on stop),
+  so the board maintains itself as the discussion progresses.
 
 ### Stage 5 — Polish ⬜
 

--- a/aar-studio/docs/PLAN.md
+++ b/aar-studio/docs/PLAN.md
@@ -1,0 +1,138 @@
+# AAR Studio — Plan
+
+**Status:** Living document — update when scope or priorities change.
+**Last updated:** June 2026 (initial version, Stages 1–2 delivered, Stage 3 partially delivered)
+
+## Vision
+
+AAR Studio is a standalone static web app (plain HTML/CSS/ES modules, **no build
+step**) that helps a fire brigade facilitator run an After Action Review end to
+end:
+
+1. **Set up** the session (incident, AAR meeting details, attending units, phases).
+2. **Capture** the discussion — room microphone, shared Teams tab audio, an
+   uploaded recording, or a pasted Teams transcript.
+3. **Analyse live** — AI extracts discrete findings into the four AAR
+   categories (*what happened / what went well / what didn't go well / what
+   would we do next time*), tagged with the incident phase, shown on a live
+   board with a projector-friendly Present mode.
+4. **Review & edit** — fix transcripts, rename speakers, curate findings.
+5. **Report** — AI drafts a structured report; every field is editable; export
+   a one-page executive snapshot (HTML), a combined HTML report, a Markdown
+   summary, and a JSON session file.
+
+Everything runs in the browser. Azure AI Speech and Azure OpenAI (Azure AI
+Foundry deployments) are called directly from the client; keys live in
+`localStorage` only. There is **no backend**. Deployment target is Azure
+Static Web Apps.
+
+The Wamboin structure fire AAR (June 2026) is the reference example: its
+summary, one-page snapshot and session data are bundled as
+`data/sample-session.json` so Review and Report are demoable without a live
+session.
+
+## Relationship to Station Manager
+
+AAR Studio lives in `aar-studio/` inside the Station-Manager repo but is fully
+self-contained: no shared code, no shared deploy. The main CI/CD pipeline
+ignores it (`paths-ignore`); it has its own workflow
+(`.github/workflows/aar-studio.yml`) that runs its node tests and deploys to
+Azure Static Web Apps.
+
+## Delivery stages
+
+### Stage 1 — Foundation ✅ (delivered)
+
+- App shell: `index.html`, hash routing, nav, toasts, dark RFS-adjacent theme.
+- Session model + `localStorage` persistence (one key per session), autosave,
+  session list / create / open / delete / JSON import & export.
+- Session setup view: incident title/date/location/type, AAR date/location,
+  facilitator, attending units (unit + role rows), configurable phases
+  (default Arrival, Rescue, Suppression, Overhaul + implicit General bucket).
+- Settings dialog: Azure OpenAI endpoint / deployment / report deployment /
+  api-version / key, Azure Speech key / region / language (en-AU default) /
+  diarization toggle; **Test connection** button; stored in `localStorage`.
+- Sample Wamboin session JSON; load-sample button on Home.
+- `staticwebapp.config.json` (CSP, Permissions-Policy), SWA deploy workflow,
+  README, node test runner (`node --test`, zero dependencies).
+
+### Stage 2 — Transcript ingest, extraction & live board ✅ (delivered)
+
+- Transcript parser (pure module): Teams DOCX copy format
+  (`Name␠␠␠m:ss` header line + text lines), `Name: text` lines, WEBVTT
+  (incl. `<v Speaker>` voice tags), plain-paragraph fallback.
+- Paste-a-transcript ingest in the Capture view; segments stored with speaker,
+  timestamp, phase, source.
+- LLM client (pure-ish module): Azure OpenAI chat completions with structured
+  outputs — `response_format: json_schema (strict)` with graceful fallback to
+  `json_object`, then plain-JSON parsing; no `temperature`/`max_tokens`
+  (reasoning-model compatible); CORS/auth/deployment error hints.
+- Extraction engine: chunked extraction over segments, AAR-specific prompt
+  (single-room-mic garble correction, "(unclear)" marking, Australian fire
+  service terminology, ignore facilitation chatter, verbatim quote + source
+  segment ids per finding), JSON schema per session phases.
+- Auto-trigger policy helper (~45 s / 70+ words, plus phase change / on
+  demand) — wired to manual "Analyse" now, reused by live audio in Stage 4.
+- Near-duplicate finding dedupe (token-set similarity + containment).
+- Live board: 4 category columns with counts, phase chips + phase filter,
+  manual quick-add, edit/delete, fullscreen high-contrast **Present mode**.
+- Review view: edit/recategorise/rephase/delete findings; edit segment text,
+  phase and speaker; rename diarised speakers (map applied everywhere).
+
+### Stage 3 — Report studio 🔶 (editing + exports delivered; AI generation next)
+
+Delivered:
+- Report data model `{headline, contextBar, stats[], snapshot[], phases[],
+  themes[], recommendations[], actions[3], assessment, caveat}`; blank
+  template creation pre-filled from session metadata.
+- Report editor with live preview (iframe), every field editable.
+- Exports: one-page executive snapshot HTML (dark header, red context bar,
+  stats row, who attended, What worked / Lessons columns, Top three actions
+  footer), Markdown summary + findings register, JSON session export,
+  print-to-PDF via the preview.
+
+Remaining:
+- **AI report generation** from the curated findings + transcript (separate
+  optional report deployment, e.g. a larger model than the live-extraction one).
+- **Combined HTML report** export (snapshot page + full summary + findings
+  register + optional transcript appendix in one file).
+
+### Stage 4 — Live audio capture ⬜
+
+- One shared audio pipeline: source (mic `getUserMedia` / tab or system audio
+  `getDisplayMedia` / decoded uploaded file) → `AudioWorklet` tap → resample →
+  16 kHz mono PCM16 → Azure Speech **push stream**; RMS level meter from the
+  same tap.
+- Azure AI Speech JS SDK (`microsoft-cognitiveservices-speech-sdk` from
+  jsDelivr, lazy-loaded), `ConversationTranscriber` with diarization toggle,
+  en-AU default; live interim results in the Capture view.
+- Optional local `MediaRecorder` backup recording offered as a download.
+- Phase clicker tags live segments; auto-extraction loop using the Stage 2
+  trigger policy (45 s / 70 words / phase change / on demand).
+
+### Stage 5 — Polish ⬜
+
+- Dedupe threshold tuning with real transcripts; merge-suggestion UI.
+- Accessibility pass (keyboard-only board operation, ARIA live regions for the
+  Present mode), print stylesheet refinements.
+- Combined-report appendix options; per-unit finding attribution.
+- Optional: ship a `?demo` deep link that auto-loads the sample session.
+
+## Architecture decisions (log)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | No build step, plain ES modules | Deployable to SWA by copying files; trivially debuggable at an incident-review timescale; no toolchain rot. |
+| 2 | Browser → Azure direct, keys in localStorage | No backend to run or secure; acceptable because keys are the operator's own and scoped resources; clearly documented trade-off. |
+| 3 | Structured outputs w/ fallback chain | `json_schema` strict where supported; older api-versions/models fall back to `json_object`, then fenced-JSON parsing. |
+| 4 | One audio pipeline for mic/tab/file | Uniform 16 kHz PCM16 push stream means STT code has a single input path; the level meter and backup recorder tap the same graph. |
+| 5 | Pure logic modules (parser, dedupe, exports, extraction policy) | Testable with `node --test` and no browser; views stay thin. |
+| 6 | One localStorage key per session | Sessions are independent, listable by key prefix, and exportable/importable as single JSON files. |
+
+## Data model (summary)
+
+See `docs/ARCHITECTURE.md` for the full schema. A session is one JSON object:
+`{ id, schemaVersion, incident, aar, units[], phases[], currentPhase,
+segments[], findings[], speakers{}, report|null, createdAt, updatedAt }`.
+Findings carry `category` (`happened|well|didnt|next`), `phase`, `text`,
+`quote`, `segmentIds[]`, `source` (`ai|manual`).

--- a/aar-studio/index.html
+++ b/aar-studio/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="AAR Studio — AI-facilitated After Action Reviews for fire brigades">
+  <title>AAR Studio</title>
+  <link rel="stylesheet" href="./css/app.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar__brand">
+      <span class="topbar__logo" aria-hidden="true">🔥</span>
+      <span class="topbar__name">AAR&nbsp;Studio</span>
+      <span class="topbar__session" id="session-label"></span>
+    </div>
+    <nav class="nav" id="nav" aria-label="Main"></nav>
+  </header>
+  <main class="view" id="view"></main>
+  <dialog class="dialog" id="settings-dialog"></dialog>
+  <script type="module" src="./js/main.js"></script>
+</body>
+</html>

--- a/aar-studio/js/analyse.js
+++ b/aar-studio/js/analyse.js
@@ -1,0 +1,74 @@
+// Shared AI analysis runner + the live auto-extraction counters.
+// Used by the Capture view (manual/phase-change), the Board view, and the
+// live listen controller (timer-driven).
+
+import { toast } from './ui.js';
+import * as store from './store.js';
+import { getSettings } from './settings.js';
+import { extractFromSegments, shouldAutoExtract } from './lib/extraction.js';
+import { dedupeFindings } from './lib/dedupe.js';
+import { LlmError } from './lib/llm.js';
+
+let analysing = false;
+let lastExtractAt = 0;
+let pendingWords = 0;
+
+export function isAnalysing() {
+  return analysing;
+}
+
+/** Live capture reports newly transcribed words here. */
+export function noteNewWords(n) {
+  pendingWords += n;
+}
+
+/** Timer-driven check: run a pass when the 45 s / 70-word policy says so. */
+export async function maybeAutoExtract() {
+  if (analysing) return;
+  if (!shouldAutoExtract({ msSinceLast: Date.now() - lastExtractAt, wordsPending: pendingWords })) return;
+  await analyseNow(null, { quiet: true });
+}
+
+/**
+ * Run extraction over all un-analysed segments.
+ * quiet=true (auto passes) only toasts when something was found or failed.
+ */
+export async function analyseNow(statusEl = null, { quiet = false } = {}) {
+  if (analysing) return;
+  const session = store.getSession();
+  if (!session) return;
+  const pending = session.segments.filter((seg) => !seg.analysed && seg.text.trim());
+  if (!pending.length) {
+    if (!quiet) toast('Nothing new to analyse — all segments are already processed');
+    return;
+  }
+  analysing = true;
+  lastExtractAt = Date.now();
+  pendingWords = 0;
+  const setStatus = (msg) => { if (statusEl) statusEl.textContent = msg; };
+  try {
+    setStatus(`Analysing ${pending.length} segment(s)…`);
+    const found = await extractFromSegments({
+      session,
+      segments: pending,
+      settings: getSettings(),
+      onProgress: (done, total) => setStatus(`Analysing… chunk ${done}/${total}`),
+    });
+    const { added, skipped } = dedupeFindings(session.findings, found);
+    store.update((s) => {
+      s.findings.push(...added);
+      const ids = new Set(pending.map((seg) => seg.id));
+      for (const seg of s.segments) if (ids.has(seg.id)) seg.analysed = true;
+    }, { reason: 'findings' });
+    setStatus('');
+    if (!quiet || added.length) {
+      toast(`${added.length} new finding(s)${skipped.length ? `, ${skipped.length} duplicate(s) skipped` : ''}`);
+    }
+  } catch (err) {
+    const hint = err instanceof LlmError && err.hint ? ` — ${err.hint}` : '';
+    toast(`${err.message}${hint}`, 'error', 8000);
+    setStatus('');
+  } finally {
+    analysing = false;
+  }
+}

--- a/aar-studio/js/audio/live.js
+++ b/aar-studio/js/audio/live.js
@@ -1,0 +1,229 @@
+// Live listen controller: one shared audio pipeline (room mic / shared tab
+// audio / uploaded file) → AudioWorklet tap → 16 kHz mono PCM16 → Azure
+// Speech push stream. Final segments land in the session tagged with the
+// current phase; auto-extraction runs on the 45 s / 70-word policy. The
+// controller is a singleton so it survives view re-renders.
+
+import * as store from '../store.js';
+import { getSettings } from '../settings.js';
+import { createSegment } from '../lib/model.js';
+import { countWords } from '../lib/text.js';
+import { rms, downsampleTo16k, createSpeakerLabeler } from '../lib/audioUtils.js';
+import { loadSpeechSdk, createTranscriber } from './speech.js';
+import { noteNewWords, maybeAutoExtract, analyseNow } from '../analyse.js';
+
+export const SOURCES = {
+  mic: { label: 'Room microphone', icon: '🎙' },
+  display: { label: 'Shared tab / system audio', icon: '🖥' },
+  file: { label: 'Audio file', icon: '📂' },
+};
+
+const state = {
+  status: 'idle', // idle | starting | listening | stopping
+  source: null,
+  startedAt: null,
+  level: 0,
+  interim: '',
+  interimSpeaker: '',
+  error: '',
+  recording: false,
+  recordingUrl: null,
+  recordingName: '',
+};
+
+export function getState() {
+  return state;
+}
+
+// Single UI listener (only the Capture view shows live state); re-registered
+// on every render so it always holds fresh DOM references.
+let uiListener = null;
+export function setUiListener(fn) {
+  uiListener = fn;
+}
+function emit(event = 'state') {
+  uiListener?.(event, state);
+}
+
+let audioCtx = null;
+let workletNode = null;
+let sourceNode = null;
+let mediaStream = null;
+let transcriber = null;
+let recorder = null;
+let autoTimer = null;
+let labeler = null;
+
+async function getInput(sourceKind, file) {
+  if (sourceKind === 'mic') {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+    return audioCtx.createMediaStreamSource(mediaStream);
+  }
+  if (sourceKind === 'display') {
+    // Video must be requested for tab/screen pickers; audio only flows if the
+    // user ticks "share audio" in the picker.
+    mediaStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
+    if (!mediaStream.getAudioTracks().length) {
+      mediaStream.getTracks().forEach((t) => t.stop());
+      mediaStream = null;
+      throw new Error('No audio in the shared source — pick the Teams tab/window and tick “Share audio” in the browser dialog');
+    }
+    return audioCtx.createMediaStreamSource(mediaStream);
+  }
+  if (sourceKind === 'file') {
+    const buffer = await audioCtx.decodeAudioData(await file.arrayBuffer());
+    const src = audioCtx.createBufferSource();
+    src.buffer = buffer;
+    src.onended = () => stop();
+    return src;
+  }
+  throw new Error(`Unknown audio source: ${sourceKind}`);
+}
+
+function startBackupRecording(sourceKind, file) {
+  if (!mediaStream || !globalThis.MediaRecorder) return;
+  try {
+    const audioOnly = new MediaStream(mediaStream.getAudioTracks());
+    recorder = new MediaRecorder(audioOnly);
+    const chunks = [];
+    recorder.ondataavailable = (e) => { if (e.data.size) chunks.push(e.data); };
+    recorder.onstop = () => {
+      if (state.recordingUrl) URL.revokeObjectURL(state.recordingUrl);
+      const blob = new Blob(chunks, { type: recorder.mimeType || 'audio/webm' });
+      state.recordingUrl = URL.createObjectURL(blob);
+      const ext = (recorder.mimeType || 'audio/webm').includes('ogg') ? 'ogg' : 'webm';
+      state.recordingName = `aar-recording-${new Date().toISOString().replace(/[:.]/g, '-')}.${ext}`;
+      state.recording = false;
+      emit();
+    };
+    recorder.start(1000);
+    state.recording = true;
+  } catch (err) {
+    console.warn('backup recording unavailable', err);
+    state.recording = false;
+  }
+  // An uploaded file needs no backup — the user already has it.
+  void sourceKind; void file;
+}
+
+function onFinal(text, speakerId, offsetSec) {
+  const trimmed = String(text ?? '').trim();
+  if (!trimmed) return;
+  const t = offsetSec != null ? Math.round(offsetSec) : Math.round((Date.now() - state.startedAt) / 1000);
+  store.update((s) => {
+    s.segments.push(createSegment({ t, speaker: labeler(speakerId), text: trimmed, phase: s.currentPhase, source: state.source === 'file' ? 'file' : 'live' }));
+  }, { reason: 'segments' });
+  state.interim = '';
+  state.interimSpeaker = '';
+  noteNewWords(countWords(trimmed));
+  // No emit needed — the store update above already re-renders the view.
+}
+
+/**
+ * Start live listening. sourceKind: 'mic' | 'display' | 'file'.
+ * options: { file?: File, backup?: boolean }
+ */
+export async function start(sourceKind, { file = null, backup = false } = {}) {
+  if (state.status !== 'idle') return;
+  const settings = getSettings();
+  state.status = 'starting';
+  state.source = sourceKind;
+  state.error = '';
+  if (state.recordingUrl) { URL.revokeObjectURL(state.recordingUrl); state.recordingUrl = null; }
+  emit();
+
+  try {
+    const sdk = await loadSpeechSdk();
+    audioCtx = new (globalThis.AudioContext || globalThis.webkitAudioContext)();
+    await audioCtx.resume();
+    await audioCtx.audioWorklet.addModule('./js/audio/worklet.js');
+
+    sourceNode = await getInput(sourceKind, file);
+
+    labeler = createSpeakerLabeler();
+    transcriber = createTranscriber({
+      sdk,
+      settings,
+      onInterim: (text, speakerId) => {
+        state.interim = text ?? '';
+        state.interimSpeaker = labeler(speakerId);
+        emit('interim');
+      },
+      onFinal,
+      onError: (message) => {
+        state.error = message;
+        emit();
+        stop();
+      },
+    });
+
+    workletNode = new AudioWorkletNode(audioCtx, 'pcm-tap');
+    const sampleRate = audioCtx.sampleRate;
+    workletNode.port.onmessage = ({ data }) => {
+      state.level = rms(data);
+      transcriber?.push(downsampleTo16k(data, sampleRate).buffer);
+      emit('level');
+    };
+    // Pull the graph through a muted gain so nothing is audible (mic would
+    // feed back) but the worklet still processes.
+    const mute = audioCtx.createGain();
+    mute.gain.value = 0;
+    sourceNode.connect(workletNode);
+    workletNode.connect(mute);
+    mute.connect(audioCtx.destination);
+
+    await transcriber.start();
+    if (sourceKind === 'file') sourceNode.start();
+    if (backup && sourceKind !== 'file') startBackupRecording(sourceKind, file);
+
+    state.status = 'listening';
+    state.startedAt = Date.now();
+    autoTimer = setInterval(() => { maybeAutoExtract(); }, 5000);
+    emit();
+
+    // If the user ends a screen-share from the browser chrome, stop cleanly.
+    mediaStream?.getTracks().forEach((track) => { track.onended = () => stop(); });
+  } catch (err) {
+    state.error = err?.message ?? String(err);
+    await teardown();
+    state.status = 'idle';
+    emit();
+  }
+}
+
+async function teardown() {
+  clearInterval(autoTimer);
+  autoTimer = null;
+  if (recorder?.state === 'recording') recorder.stop();
+  recorder = null;
+  try { workletNode?.port.close(); workletNode?.disconnect(); } catch { /* already gone */ }
+  workletNode = null;
+  try { sourceNode?.stop?.(); sourceNode?.disconnect(); } catch { /* buffer sources throw if never started */ }
+  sourceNode = null;
+  mediaStream?.getTracks().forEach((t) => t.stop());
+  mediaStream = null;
+  const t = transcriber;
+  transcriber = null;
+  await t?.stop().catch(() => {});
+  await audioCtx?.close().catch(() => {});
+  audioCtx = null;
+  state.level = 0;
+  state.interim = '';
+  state.interimSpeaker = '';
+}
+
+export async function stop() {
+  if (state.status !== 'listening' && state.status !== 'starting') return;
+  state.status = 'stopping';
+  emit();
+  await teardown();
+  state.status = 'idle';
+  emit();
+  // Wrap up: analyse whatever the last extraction pass hasn't seen.
+  const session = store.getSession();
+  if (session?.segments.some((seg) => !seg.analysed && seg.text.trim())) {
+    analyseNow(null, { quiet: true });
+  }
+}

--- a/aar-studio/js/audio/speech.js
+++ b/aar-studio/js/audio/speech.js
@@ -1,0 +1,90 @@
+// Azure AI Speech SDK: lazy load from jsDelivr + a thin transcriber wrapper
+// over ConversationTranscriber (diarization on) / SpeechRecognizer (off),
+// fed by a 16 kHz mono PCM16 push stream.
+
+const SDK_URL = 'https://cdn.jsdelivr.net/npm/microsoft-cognitiveservices-speech-sdk@1.42.0/distrib/browser/microsoft.cognitiveservices.speech.sdk.bundle-min.js';
+
+let sdkPromise = null;
+
+/** Inject the UMD bundle once (CSP allows cdn.jsdelivr.net) and return SpeechSDK. */
+export function loadSpeechSdk() {
+  if (!sdkPromise) {
+    sdkPromise = new Promise((resolve, reject) => {
+      if (globalThis.SpeechSDK) return resolve(globalThis.SpeechSDK);
+      const script = document.createElement('script');
+      script.src = SDK_URL;
+      script.onload = () => {
+        if (globalThis.SpeechSDK) resolve(globalThis.SpeechSDK);
+        else reject(new Error('Speech SDK script loaded but SpeechSDK global is missing'));
+      };
+      script.onerror = () => {
+        sdkPromise = null; // allow retry
+        reject(new Error('Could not load the Azure Speech SDK from cdn.jsdelivr.net — check the network connection and that the CSP allows jsDelivr'));
+      };
+      document.head.append(script);
+    });
+  }
+  return sdkPromise;
+}
+
+/**
+ * Create a live transcriber over a push stream.
+ * Callbacks: onInterim(text, speakerId), onFinal(text, speakerId, offsetSec),
+ * onError(message).
+ * Returns { start, stop, push } — push takes an ArrayBuffer of PCM16 @16 kHz.
+ */
+export function createTranscriber({ sdk, settings, onInterim, onFinal, onError }) {
+  if (!settings.speechKey || !settings.speechRegion) {
+    throw new Error('No Azure Speech key/region configured — open Settings and fill in the Speech section');
+  }
+  const speechConfig = sdk.SpeechConfig.fromSubscription(settings.speechKey, settings.speechRegion);
+  speechConfig.speechRecognitionLanguage = settings.language || 'en-AU';
+
+  const format = sdk.AudioStreamFormat.getWaveFormatPCM(16000, 16, 1);
+  const pushStream = sdk.AudioInputStream.createPushStream(format);
+  const audioConfig = sdk.AudioConfig.fromStreamInput(pushStream);
+
+  const offsetSec = (result) => (result.offset != null ? result.offset / 1e7 : null); // 100 ns ticks
+  const handleCanceled = (e) => {
+    if (e.reason === sdk.CancellationReason.Error) {
+      onError(`Speech service error: ${e.errorDetails || e.errorCode}. Check the Speech key/region in Settings.`);
+    }
+  };
+
+  let engine;
+  let startFn;
+  let stopFn;
+  if (settings.diarization) {
+    engine = new sdk.ConversationTranscriber(speechConfig, audioConfig);
+    engine.transcribing = (_, e) => onInterim(e.result.text, e.result.speakerId);
+    engine.transcribed = (_, e) => {
+      if (e.result.reason === sdk.ResultReason.RecognizedSpeech && e.result.text) {
+        onFinal(e.result.text, e.result.speakerId, offsetSec(e.result));
+      }
+    };
+    engine.canceled = (_, e) => handleCanceled(e);
+    startFn = (res, rej) => engine.startTranscribingAsync(res, rej);
+    stopFn = (res, rej) => engine.stopTranscribingAsync(res, rej);
+  } else {
+    engine = new sdk.SpeechRecognizer(speechConfig, audioConfig);
+    engine.recognizing = (_, e) => onInterim(e.result.text, null);
+    engine.recognized = (_, e) => {
+      if (e.result.reason === sdk.ResultReason.RecognizedSpeech && e.result.text) {
+        onFinal(e.result.text, null, offsetSec(e.result));
+      }
+    };
+    engine.canceled = (_, e) => handleCanceled(e);
+    startFn = (res, rej) => engine.startContinuousRecognitionAsync(res, rej);
+    stopFn = (res, rej) => engine.stopContinuousRecognitionAsync(res, rej);
+  }
+
+  return {
+    start: () => new Promise((res, rej) => startFn(res, rej)),
+    stop: () =>
+      new Promise((res) => stopFn(res, res)).then(() => {
+        pushStream.close();
+        engine.close();
+      }),
+    push: (arrayBuffer) => pushStream.write(arrayBuffer),
+  };
+}

--- a/aar-studio/js/audio/worklet.js
+++ b/aar-studio/js/audio/worklet.js
@@ -1,0 +1,32 @@
+// AudioWorklet processor: taps channel 0 and posts ~1024-frame Float32
+// blocks to the main thread (which meters, resamples and feeds the Speech
+// SDK push stream). Loaded via audioWorklet.addModule(); not an ES module
+// import — keep it dependency-free.
+
+class PcmTapProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buffer = new Float32Array(1024);
+    this.offset = 0;
+  }
+
+  process(inputs) {
+    const channel = inputs[0]?.[0];
+    if (channel) {
+      let read = 0;
+      while (read < channel.length) {
+        const n = Math.min(channel.length - read, this.buffer.length - this.offset);
+        this.buffer.set(channel.subarray(read, read + n), this.offset);
+        this.offset += n;
+        read += n;
+        if (this.offset === this.buffer.length) {
+          this.port.postMessage(this.buffer.slice());
+          this.offset = 0;
+        }
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor('pcm-tap', PcmTapProcessor);

--- a/aar-studio/js/lib/audioUtils.js
+++ b/aar-studio/js/lib/audioUtils.js
@@ -1,0 +1,51 @@
+// Pure audio helpers: resampling to the 16 kHz mono PCM16 the Speech SDK
+// push stream wants, level metering, and stable diarised-speaker labels.
+// No DOM / Web Audio — covered by node --test.
+
+/** Root-mean-square level of a Float32 block (0..~1). */
+export function rms(float32) {
+  if (!float32?.length) return 0;
+  let sum = 0;
+  for (let i = 0; i < float32.length; i++) sum += float32[i] * float32[i];
+  return Math.sqrt(sum / float32.length);
+}
+
+/** Clamp a float sample [-1,1] to a signed 16-bit int. */
+export function floatToPcm16(sample) {
+  const s = Math.max(-1, Math.min(1, sample));
+  return Math.round(s < 0 ? s * 0x8000 : s * 0x7fff);
+}
+
+/**
+ * Downsample a Float32 block at `fromRate` to 16 kHz mono PCM16
+ * (linear interpolation — fine for speech).
+ * @returns {Int16Array}
+ */
+export function downsampleTo16k(float32, fromRate, toRate = 16000) {
+  if (fromRate < toRate) throw new Error(`Cannot upsample ${fromRate} → ${toRate}`);
+  if (fromRate === toRate) return Int16Array.from(float32, floatToPcm16);
+  const ratio = fromRate / toRate;
+  const outLength = Math.floor(float32.length / ratio);
+  const out = new Int16Array(outLength);
+  for (let i = 0; i < outLength; i++) {
+    const pos = i * ratio;
+    const i0 = Math.floor(pos);
+    const i1 = Math.min(i0 + 1, float32.length - 1);
+    const frac = pos - i0;
+    out[i] = floatToPcm16(float32[i0] * (1 - frac) + float32[i1] * frac);
+  }
+  return out;
+}
+
+/**
+ * Stable display labels for diarised speaker ids ("Guest-1" → "Speaker 1",
+ * first-seen order). Unknown/absent ids get no label.
+ */
+export function createSpeakerLabeler() {
+  const map = new Map();
+  return (rawId) => {
+    if (!rawId || rawId === 'Unknown') return '';
+    if (!map.has(rawId)) map.set(rawId, `Speaker ${map.size + 1}`);
+    return map.get(rawId);
+  };
+}

--- a/aar-studio/js/lib/dedupe.js
+++ b/aar-studio/js/lib/dedupe.js
@@ -1,0 +1,58 @@
+// Near-duplicate finding detection. Pure.
+//
+// Live extraction re-reads overlapping context, so the model often restates a
+// finding it already produced. We treat two findings as duplicates when their
+// normalised token sets are highly similar (Jaccard) or one is contained in
+// the other (short restatement of a longer finding).
+
+const STOP = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'at', 'for', 'with',
+  'was', 'were', 'is', 'are', 'be', 'been', 'it', 'that', 'this', 'we', 'they',
+  'had', 'have', 'has', 'not', 'no', 'but', 'as', 'by', 'from', 'up', 'so',
+]);
+
+export function tokens(text) {
+  return new Set(
+    String(text ?? '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter((w) => w.length > 1 && !STOP.has(w)),
+  );
+}
+
+export function similarity(a, b) {
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (!ta.size || !tb.size) return 0;
+  let inter = 0;
+  for (const w of ta) if (tb.has(w)) inter++;
+  const jaccard = inter / (ta.size + tb.size - inter);
+  const containment = inter / Math.min(ta.size, tb.size);
+  // Containment catches "A restated more briefly"; require a few shared
+  // tokens so two 2-word findings don't collapse together.
+  return Math.max(jaccard, inter >= 4 ? containment : 0);
+}
+
+export function isNearDuplicate(a, b, threshold = 0.72) {
+  if (a.category !== b.category) return false;
+  return similarity(a.text, b.text) >= threshold;
+}
+
+/**
+ * Filter incoming findings against existing ones (and each other).
+ * Returns { added, skipped } — `added` are safe to append.
+ */
+export function dedupeFindings(existing, incoming, threshold = 0.72) {
+  const kept = [...existing];
+  const added = [];
+  const skipped = [];
+  for (const f of incoming) {
+    if (kept.some((e) => isNearDuplicate(e, f, threshold))) skipped.push(f);
+    else {
+      kept.push(f);
+      added.push(f);
+    }
+  }
+  return { added, skipped };
+}

--- a/aar-studio/js/lib/exports.js
+++ b/aar-studio/js/lib/exports.js
@@ -34,45 +34,7 @@ function subLine(session) {
   return bits.join(' &nbsp;&middot;&nbsp; ');
 }
 
-/**
- * One-page executive snapshot, a standalone HTML document: dark header,
- * red context bar, stats row, the incident, who attended, What worked /
- * Lessons columns, Top three actions footer.
- */
-export function renderSnapshotHtml(session) {
-  const r = session.report ?? emptyReport(session);
-  const stats = (r.stats ?? []).filter((s) => s.value || s.label);
-  const statsRow = stats.length
-    ? `<table class="factrow"><tr>${stats.map((s) => `<td><span class="num">${esc(s.value)}</span><span class="lbl">${esc(s.label)}</span></td>`).join('')}</tr></table>`
-    : '';
-
-  const unitRows = [];
-  const units = session.units ?? [];
-  for (let i = 0; i < units.length; i += 2) {
-    const pair = [units[i], units[i + 1]].filter(Boolean)
-      .map((u) => `<td class="unit">${esc(u.unit)}</td><td>${esc(u.role)}</td>`).join('\n          ');
-    unitRows.push(`      <tr>${pair}</tr>`);
-  }
-
-  const well = (r.phases ?? []).flatMap((p) => p.well ?? []);
-  const didnt = (r.phases ?? []).flatMap((p) => p.didnt ?? []);
-  const bullet = (text) => {
-    // "Bold lead. rest" — bold up to the first sentence break, like the example.
-    const m = String(text).match(/^(.{3,80}?[.:])\s+(.*)$/s);
-    return m ? `<li><b>${esc(m[1])}</b> ${esc(m[2])}</li>` : `<li>${esc(text)}</li>`;
-  };
-
-  const themes = (r.themes ?? []).filter((t) => t.title || t.body)
-    .map((t) => `<h2>${esc(t.title)}</h2><div class="incident"><p>${esc(t.body)}</p></div>`).join('\n');
-
-  const actions = (r.actions ?? []).filter(Boolean);
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>${esc(r.headline || session.incident.title || 'AAR Snapshot')}</title>
-<style>
+const SNAPSHOT_CSS = `
   * { margin:0; padding:0; box-sizing:border-box; }
   body { font-family: Helvetica, Arial, sans-serif; color:#1a1f24; font-size:9.2pt; line-height:1.32; }
   .page { max-width:210mm; margin:0 auto; }
@@ -112,10 +74,39 @@ export function renderSnapshotHtml(session) {
   .actions .n { color:#e8b84b; font-weight:bold; font-size:11pt; padding-right:6px; }
   .footer { padding:7px 24px 10px 24px; font-size:7.2pt; color:#7a8590; }
   @media print { .page { max-width:none; } }
-</style>
-</head>
-<body>
-<div class="page">
+`;
+
+/** "Bold lead. rest" — bold up to the first sentence break, like the artwork. */
+function leadBullet(text) {
+  const m = String(text).match(/^(.{3,80}?[.:])\s+(.*)$/s);
+  return m ? `<li><b>${esc(m[1])}</b> ${esc(m[2])}</li>` : `<li>${esc(text)}</li>`;
+}
+
+/** Inner snapshot markup (everything inside <body>), shared with the combined report. */
+function snapshotBody(session) {
+  const r = session.report ?? emptyReport(session);
+  const stats = (r.stats ?? []).filter((s) => s.value || s.label);
+  const statsRow = stats.length
+    ? `<table class="factrow"><tr>${stats.map((s) => `<td><span class="num">${esc(s.value)}</span><span class="lbl">${esc(s.label)}</span></td>`).join('')}</tr></table>`
+    : '';
+
+  const unitRows = [];
+  const units = session.units ?? [];
+  for (let i = 0; i < units.length; i += 2) {
+    const pair = [units[i], units[i + 1]].filter(Boolean)
+      .map((u) => `<td class="unit">${esc(u.unit)}</td><td>${esc(u.role)}</td>`).join('\n          ');
+    unitRows.push(`      <tr>${pair}</tr>`);
+  }
+
+  const well = (r.phases ?? []).flatMap((p) => p.well ?? []);
+  const didnt = (r.phases ?? []).flatMap((p) => p.didnt ?? []);
+
+  const themes = (r.themes ?? []).filter((t) => t.title || t.body)
+    .map((t) => `<h2>${esc(t.title)}</h2><div class="incident"><p>${esc(t.body)}</p></div>`).join('\n');
+
+  const actions = (r.actions ?? []).filter(Boolean);
+
+  return `<div class="page">
   <div class="header">
     <div class="kicker">After Action Review &mdash; Executive Snapshot</div>
     <h1>${esc(r.headline || session.incident.title)}</h1>
@@ -134,13 +125,13 @@ ${unitRows.join('\n')}
       <td class="left">
         <div class="colhead good">What worked</div>
         <ul class="g">
-${well.map(bullet).join('\n')}
+${well.map(leadBullet).join('\n')}
         </ul>
       </td>
       <td class="right">
         <div class="colhead bad">Lessons &mdash; fix next time</div>
         <ul class="b">
-${didnt.map(bullet).join('\n')}
+${didnt.map(leadBullet).join('\n')}
         </ul>
       </td>
     </tr></tbody></table>
@@ -154,7 +145,25 @@ ${actions.map((a, i) => `      <td><span class="n">${i + 1}</span>${esc(a)}</td>
   </div>` : ''}
 ${r.assessment ? `  <div class="section"><h2>Overall assessment</h2><div class="incident"><p>${esc(r.assessment)}</p></div></div>` : ''}
 ${r.caveat ? `  <div class="footer">${esc(r.caveat)}</div>` : ''}
-</div>
+</div>`;
+}
+
+/**
+ * One-page executive snapshot, a standalone HTML document: dark header,
+ * red context bar, stats row, the incident, who attended, What worked /
+ * Lessons columns, Top three actions footer.
+ */
+export function renderSnapshotHtml(session) {
+  const r = session.report ?? emptyReport(session);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${esc(r.headline || session.incident.title || 'AAR Snapshot')}</title>
+<style>${SNAPSHOT_CSS}</style>
+</head>
+<body>
+${snapshotBody(session)}
 </body>
 </html>
 `;
@@ -239,6 +248,113 @@ export function renderTranscriptText(session) {
       return `${t}${sp}${s.text}`;
     })
     .join('\n\n');
+}
+
+const COMBINED_CSS = `
+  .doc { max-width:210mm; margin:0 auto; padding:0 24px 24px; }
+  .doc h1 { font-size:14pt; color:#15212b; margin:18px 0 8px; }
+  .doc h3 { font-size:9.5pt; margin:8px 0 3px; color:#15212b; }
+  .doc p { margin-bottom:6px; }
+  .doc ol { margin:4px 0 8px 18px; }
+  .doc ol li { margin-bottom:4px; font-size:8.7pt; }
+  .meta { font-size:8.4pt; color:#4a5560; margin-bottom:8px; }
+  .register { width:100%; border-collapse:collapse; margin-top:4px; }
+  .register th { text-align:left; font-size:7.4pt; text-transform:uppercase; letter-spacing:0.6px; color:#4a5560; border-bottom:2px solid #c8102e; padding:3px 6px 3px 0; }
+  .register td { font-size:8.4pt; padding:3px 8px 3px 0; border-bottom:1px solid #dde3e8; vertical-align:top; }
+  .register .cat { white-space:nowrap; font-weight:bold; }
+  .register .quote { color:#4a5560; font-style:italic; }
+  .transcript p { font-size:8.4pt; margin-bottom:5px; }
+  .transcript .who { font-weight:bold; color:#15212b; }
+  .transcript .t { color:#7a8590; font-family:Consolas,monospace; font-size:7.6pt; padding-right:4px; }
+  .pagebreak { break-before:page; page-break-before:always; }
+`;
+
+function summarySection(session) {
+  const r = session.report ?? emptyReport(session);
+  const out = [`<div class="doc pagebreak">`, `<h1>Full summary</h1>`];
+  const meta = [];
+  if (session.aar.date || session.aar.location) meta.push(`AAR conducted ${esc([session.aar.date, session.aar.location].filter(Boolean).join(', '))}`);
+  if (session.aar.facilitator) meta.push(`Facilitator: ${esc(session.aar.facilitator)}`);
+  if (session.phases?.length) meta.push(`Format: ${esc(session.phases.join(' → '))}`);
+  if (meta.length) out.push(`<p class="meta">${meta.join(' &nbsp;&middot;&nbsp; ')}</p>`);
+
+  for (const p of r.phases ?? []) {
+    if (!p.happened && !(p.well?.length) && !(p.didnt?.length)) continue;
+    out.push(`<h2>${esc(p.name)}</h2>`);
+    if (p.happened) out.push(`<p>${esc(p.happened)}</p>`);
+    if (p.well?.length) out.push(`<h3>What went well</h3><ul class="g">${p.well.map(leadBullet).join('')}</ul>`);
+    if (p.didnt?.length) out.push(`<h3>What didn&rsquo;t / lessons</h3><ul class="b">${p.didnt.map(leadBullet).join('')}</ul>`);
+  }
+  for (const t of r.themes ?? []) {
+    if (!t.title && !t.body) continue;
+    out.push(`<h2>${esc(t.title)}</h2><p>${esc(t.body)}</p>`);
+  }
+  if (r.recommendations?.length) {
+    out.push(`<h2>Consolidated recommendations</h2><ol>${r.recommendations.map((rec) => `<li>${esc(rec)}</li>`).join('')}</ol>`);
+  }
+  const actions = (r.actions ?? []).filter(Boolean);
+  if (actions.length) out.push(`<h2>Top three actions</h2><ol>${actions.map((a) => `<li><b>${esc(a)}</b></li>`).join('')}</ol>`);
+  if (r.assessment) out.push(`<h2>Overall assessment</h2><p>${esc(r.assessment)}</p>`);
+  out.push('</div>');
+  return out.join('\n');
+}
+
+function registerSection(session) {
+  if (!session.findings?.length) return '';
+  const rows = [];
+  for (const phase of sessionPhases(session)) {
+    for (const cat of CATEGORIES) {
+      for (const f of session.findings.filter((x) => x.phase === phase && x.category === cat.id)) {
+        const quote = f.quote ? `<div class="quote">&ldquo;${esc(f.quote)}&rdquo;</div>` : '';
+        rows.push(`<tr><td>${esc(phase)}</td><td class="cat">${esc(cat.short)}</td><td>${esc(f.text)}${quote}</td></tr>`);
+      }
+    }
+  }
+  return `<div class="doc pagebreak">
+<h1>Findings register</h1>
+<p class="meta">${session.findings.length} findings captured during the AAR.</p>
+<table class="register">
+<thead><tr><th>Phase</th><th>Category</th><th>Finding</th></tr></thead>
+<tbody>${rows.join('\n')}</tbody>
+</table>
+</div>`;
+}
+
+function transcriptSection(session) {
+  if (!session.segments?.length) return '';
+  const paras = session.segments.map((s) => {
+    const t = s.t != null ? `<span class="t">[${fmtClock(s.t)}]</span>` : '';
+    const who = s.speaker ? `<span class="who">${esc(speakerName(session, s.speaker))}:</span> ` : '';
+    return `<p>${t}${who}${esc(s.text)}</p>`;
+  });
+  return `<div class="doc pagebreak transcript">
+<h1>Appendix — transcript</h1>
+<p class="meta">${session.segments.length} segments. Machine transcription — wording is approximate.</p>
+${paras.join('\n')}
+</div>`;
+}
+
+/**
+ * Combined report: snapshot page + full summary + findings register +
+ * optional transcript appendix, one standalone printable HTML document.
+ */
+export function renderCombinedHtml(session, { includeTranscript = false } = {}) {
+  const r = session.report ?? emptyReport(session);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${esc(r.headline || session.incident.title || 'AAR Report')}</title>
+<style>${SNAPSHOT_CSS}${COMBINED_CSS}</style>
+</head>
+<body>
+${snapshotBody(session)}
+${summarySection(session)}
+${registerSection(session)}
+${includeTranscript ? transcriptSection(session) : ''}
+</body>
+</html>
+`;
 }
 
 // re-export for view convenience

--- a/aar-studio/js/lib/exports.js
+++ b/aar-studio/js/lib/exports.js
@@ -1,0 +1,245 @@
+// Report template + export renderers (one-page snapshot HTML, Markdown
+// summary, findings register). Pure string building — testable under node.
+
+import { CATEGORIES, GENERAL_PHASE, categoryLabel, sessionPhases, speakerName } from './model.js';
+import { escapeHtml as esc, fmtClock, slugify } from './text.js';
+
+/** Blank report structure, pre-filled from session metadata. */
+export function emptyReport(session) {
+  return {
+    headline: session.incident.title || '',
+    contextBar: '',
+    stats: [],                       // [{ value, label }] — aim for 4–6
+    snapshot: [],                    // paragraphs
+    phases: (session.phases ?? []).map((name) => ({ name, happened: '', well: [], didnt: [] })),
+    themes: [],                      // [{ title, body }] — 0–3 cross-cutting
+    recommendations: [],             // strings
+    actions: ['', '', ''],           // top three
+    assessment: '',
+    caveat: 'Compiled from the AAR meeting transcript — verify names, callsigns and figures before wider distribution.',
+  };
+}
+
+export function sessionFilename(session, suffix, ext) {
+  return `${slugify(session.incident.title || 'aar')}-${suffix}.${ext}`;
+}
+
+function subLine(session) {
+  const bits = [];
+  if (session.incident.type) bits.push(esc(session.incident.type));
+  const aarBits = [];
+  if (session.aar.date) aarBits.push(`AAR held ${esc(session.aar.date)}`);
+  if (session.aar.location) aarBits.push(esc(session.aar.location));
+  if (aarBits.length) bits.push(aarBits.join(', '));
+  return bits.join(' &nbsp;&middot;&nbsp; ');
+}
+
+/**
+ * One-page executive snapshot, a standalone HTML document: dark header,
+ * red context bar, stats row, the incident, who attended, What worked /
+ * Lessons columns, Top three actions footer.
+ */
+export function renderSnapshotHtml(session) {
+  const r = session.report ?? emptyReport(session);
+  const stats = (r.stats ?? []).filter((s) => s.value || s.label);
+  const statsRow = stats.length
+    ? `<table class="factrow"><tr>${stats.map((s) => `<td><span class="num">${esc(s.value)}</span><span class="lbl">${esc(s.label)}</span></td>`).join('')}</tr></table>`
+    : '';
+
+  const unitRows = [];
+  const units = session.units ?? [];
+  for (let i = 0; i < units.length; i += 2) {
+    const pair = [units[i], units[i + 1]].filter(Boolean)
+      .map((u) => `<td class="unit">${esc(u.unit)}</td><td>${esc(u.role)}</td>`).join('\n          ');
+    unitRows.push(`      <tr>${pair}</tr>`);
+  }
+
+  const well = (r.phases ?? []).flatMap((p) => p.well ?? []);
+  const didnt = (r.phases ?? []).flatMap((p) => p.didnt ?? []);
+  const bullet = (text) => {
+    // "Bold lead. rest" — bold up to the first sentence break, like the example.
+    const m = String(text).match(/^(.{3,80}?[.:])\s+(.*)$/s);
+    return m ? `<li><b>${esc(m[1])}</b> ${esc(m[2])}</li>` : `<li>${esc(text)}</li>`;
+  };
+
+  const themes = (r.themes ?? []).filter((t) => t.title || t.body)
+    .map((t) => `<h2>${esc(t.title)}</h2><div class="incident"><p>${esc(t.body)}</p></div>`).join('\n');
+
+  const actions = (r.actions ?? []).filter(Boolean);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${esc(r.headline || session.incident.title || 'AAR Snapshot')}</title>
+<style>
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body { font-family: Helvetica, Arial, sans-serif; color:#1a1f24; font-size:9.2pt; line-height:1.32; }
+  .page { max-width:210mm; margin:0 auto; }
+  .header { background:#15212b; color:#fff; padding:16px 24px 13px 24px; }
+  .header .kicker { font-size:8pt; letter-spacing:2.5px; color:#e8b84b; text-transform:uppercase; font-weight:bold; }
+  .header h1 { font-size:19pt; font-weight:bold; margin-top:3px; letter-spacing:0.3px; }
+  .header .sub { font-size:9pt; color:#b9c4cd; margin-top:4px; }
+  .header .sub b { color:#fff; }
+  .redbar { background:#c8102e; color:#fff; padding:6px 24px; font-size:8.6pt; }
+  .section { padding:0 24px; }
+  .factrow { width:100%; border-collapse:collapse; margin-top:10px; table-layout:fixed; }
+  .factrow td { text-align:center; padding:7px 4px; background:#f1f4f6; border-left:3px solid #fff; vertical-align:top; }
+  .factrow td:first-child { border-left:none; }
+  .factrow .num { font-size:15pt; font-weight:bold; color:#c8102e; display:block; }
+  .factrow .lbl { font-size:7.2pt; text-transform:uppercase; letter-spacing:0.6px; color:#4a5560; display:block; margin-top:2px; }
+  h2 { font-size:9.5pt; text-transform:uppercase; letter-spacing:1.4px; color:#15212b; border-bottom:2px solid #c8102e; padding-bottom:2px; margin:11px 0 5px 0; }
+  .incident p { margin-bottom:4px; }
+  .brigades { width:100%; border-collapse:collapse; margin-top:2px; }
+  .brigades td { font-size:8.4pt; padding:3px 8px 3px 0; vertical-align:top; }
+  .brigades .unit { font-weight:bold; white-space:nowrap; color:#15212b; padding-right:10px; }
+  .cols { width:100%; border-collapse:collapse; margin-top:2px; }
+  .cols > tbody > tr > td { width:50%; vertical-align:top; }
+  .cols td.left { padding-right:11px; }
+  .cols td.right { padding-left:11px; border-left:1px solid #dde3e8; }
+  .colhead { font-size:9pt; font-weight:bold; text-transform:uppercase; letter-spacing:1px; padding:4px 8px; margin-bottom:5px; color:#fff; }
+  .good { background:#1f7a4d; }
+  .bad  { background:#c8102e; }
+  ul { list-style:none; }
+  ul li { padding-left:13px; position:relative; margin-bottom:4px; font-size:8.7pt; }
+  ul.g li:before { content:"+"; position:absolute; left:0; color:#1f7a4d; font-weight:bold; }
+  ul.b li:before { content:"!"; position:absolute; left:0; color:#c8102e; font-weight:bold; }
+  li b { color:#15212b; }
+  .actions { background:#15212b; color:#fff; margin:11px 24px 0 24px; padding:9px 14px 8px 14px; }
+  .actions .ah { font-size:8pt; letter-spacing:2px; text-transform:uppercase; color:#e8b84b; font-weight:bold; margin-bottom:4px; }
+  .actions table { width:100%; border-collapse:collapse; }
+  .actions td { vertical-align:top; font-size:8.4pt; line-height:1.3; padding-right:12px; width:33%; }
+  .actions .n { color:#e8b84b; font-weight:bold; font-size:11pt; padding-right:6px; }
+  .footer { padding:7px 24px 10px 24px; font-size:7.2pt; color:#7a8590; }
+  @media print { .page { max-width:none; } }
+</style>
+</head>
+<body>
+<div class="page">
+  <div class="header">
+    <div class="kicker">After Action Review &mdash; Executive Snapshot</div>
+    <h1>${esc(r.headline || session.incident.title)}</h1>
+    <div class="sub">${subLine(session)}</div>
+  </div>
+${r.contextBar ? `  <div class="redbar">${esc(r.contextBar)}</div>` : ''}
+  <div class="section">
+    ${statsRow}
+${(r.snapshot ?? []).length ? `    <h2>The incident</h2>
+    <div class="incident">${(r.snapshot ?? []).map((p) => `<p>${esc(p)}</p>`).join('\n')}</div>` : ''}
+${unitRows.length ? `    <h2>Who attended</h2>
+    <table class="brigades">
+${unitRows.join('\n')}
+    </table>` : ''}
+    <table class="cols"><tbody><tr>
+      <td class="left">
+        <div class="colhead good">What worked</div>
+        <ul class="g">
+${well.map(bullet).join('\n')}
+        </ul>
+      </td>
+      <td class="right">
+        <div class="colhead bad">Lessons &mdash; fix next time</div>
+        <ul class="b">
+${didnt.map(bullet).join('\n')}
+        </ul>
+      </td>
+    </tr></tbody></table>
+${themes}
+  </div>
+${actions.length ? `  <div class="actions">
+    <div class="ah">Top three actions</div>
+    <table><tr>
+${actions.map((a, i) => `      <td><span class="n">${i + 1}</span>${esc(a)}</td>`).join('\n')}
+    </tr></table>
+  </div>` : ''}
+${r.assessment ? `  <div class="section"><h2>Overall assessment</h2><div class="incident"><p>${esc(r.assessment)}</p></div></div>` : ''}
+${r.caveat ? `  <div class="footer">${esc(r.caveat)}</div>` : ''}
+</div>
+</body>
+</html>
+`;
+}
+
+/** Markdown summary document (report + findings register). */
+export function renderMarkdown(session) {
+  const r = session.report ?? emptyReport(session);
+  const out = [];
+  out.push(`# After Action Review — ${r.headline || session.incident.title || 'Untitled incident'}`, '');
+  const meta = [];
+  if (session.aar.date || session.aar.location) meta.push(`**AAR conducted:** ${[session.aar.date, session.aar.location].filter(Boolean).join(', ')}`);
+  if (session.aar.facilitator) meta.push(`**Facilitator:** ${session.aar.facilitator}`);
+  if (session.incident.date || session.incident.location) meta.push(`**Incident:** ${[session.incident.type, session.incident.date, session.incident.location].filter(Boolean).join(', ')}`);
+  if (session.phases?.length) meta.push(`**Format:** ${session.phases.join(' → ')}`);
+  if (r.caveat) meta.push(`**Note:** ${r.caveat}`);
+  if (meta.length) out.push(meta.join('\n'), '');
+
+  if (r.contextBar) out.push(`> ${r.contextBar}`, '');
+  if (r.stats?.length) {
+    out.push('| | |', '|---|---|');
+    for (const s of r.stats) out.push(`| **${s.value}** | ${s.label} |`);
+    out.push('');
+  }
+  if (r.snapshot?.length) out.push('## Incident snapshot', '', ...r.snapshot.flatMap((p) => [p, '']));
+
+  if (session.units?.length) {
+    out.push('## Attending units', '', '| Unit | Role |', '|------|------|');
+    for (const u of session.units) out.push(`| ${u.unit} | ${u.role} |`);
+    out.push('');
+  }
+
+  for (const p of r.phases ?? []) {
+    if (!p.happened && !(p.well?.length) && !(p.didnt?.length)) continue;
+    out.push(`## ${p.name}`, '');
+    if (p.happened) out.push(p.happened, '');
+    if (p.well?.length) out.push('### What went well', '', ...p.well.map((b) => `- ${b}`), '');
+    if (p.didnt?.length) out.push("### What didn't / lessons", '', ...p.didnt.map((b) => `- ${b}`), '');
+  }
+
+  for (const t of r.themes ?? []) {
+    if (!t.title && !t.body) continue;
+    out.push(`## ${t.title}`, '', t.body, '');
+  }
+
+  if (r.recommendations?.length) {
+    out.push('## Consolidated recommendations', '', ...r.recommendations.map((rec, i) => `${i + 1}. ${rec}`), '');
+  }
+  const actions = (r.actions ?? []).filter(Boolean);
+  if (actions.length) out.push('## Top three actions', '', ...actions.map((a, i) => `${i + 1}. **${a}**`), '');
+  if (r.assessment) out.push('## Overall assessment', '', r.assessment, '');
+
+  out.push(...renderFindingsRegister(session));
+  return out.join('\n');
+}
+
+/** Findings register section (Markdown lines). */
+export function renderFindingsRegister(session) {
+  if (!session.findings?.length) return [];
+  const out = ['## Findings register', ''];
+  for (const phase of sessionPhases(session)) {
+    const inPhase = session.findings.filter((f) => f.phase === phase);
+    if (!inPhase.length) continue;
+    out.push(`### ${phase}`, '');
+    for (const cat of CATEGORIES) {
+      for (const f of inPhase.filter((x) => x.category === cat.id)) {
+        const quote = f.quote ? ` — “${f.quote}”` : '';
+        out.push(`- **[${cat.short}]** ${f.text}${quote}`);
+      }
+    }
+    out.push('');
+  }
+  return out;
+}
+
+/** Plain-text transcript (speaker rename map applied) for appendices. */
+export function renderTranscriptText(session) {
+  return (session.segments ?? [])
+    .map((s) => {
+      const t = s.t != null ? `[${fmtClock(s.t)}] ` : '';
+      const sp = s.speaker ? `${speakerName(session, s.speaker)}: ` : '';
+      return `${t}${sp}${s.text}`;
+    })
+    .join('\n\n');
+}
+
+// re-export for view convenience
+export { categoryLabel, GENERAL_PHASE };

--- a/aar-studio/js/lib/extraction.js
+++ b/aar-studio/js/lib/extraction.js
@@ -1,0 +1,141 @@
+// Finding extraction: prompts, JSON schema, chunking and the live trigger
+// policy. The only impure part is the chatJson call.
+
+import { chatJson } from './llm.js';
+import { CATEGORIES, CATEGORY_IDS, GENERAL_PHASE, sessionPhases, createFinding } from './model.js';
+import { countWords, fmtClock } from './text.js';
+
+/** Live auto-extraction policy: ≥45 s elapsed AND ≥70 new words pending. */
+export const TRIGGER = { minMs: 45_000, minWords: 70 };
+
+export function shouldAutoExtract({ msSinceLast, wordsPending }) {
+  return msSinceLast >= TRIGGER.minMs && wordsPending >= TRIGGER.minWords;
+}
+
+/**
+ * Group consecutive segments into chunks of ~maxWords for one LLM call each,
+ * breaking on phase boundaries so phase context stays coherent.
+ */
+export function chunkSegments(segments, maxWords = 450) {
+  const chunks = [];
+  let current = [];
+  let words = 0;
+  for (const seg of segments) {
+    const w = countWords(seg.text);
+    const phaseBreak = current.length && current[current.length - 1].phase !== seg.phase;
+    if (current.length && (words + w > maxWords || phaseBreak)) {
+      chunks.push(current);
+      current = [];
+      words = 0;
+    }
+    current.push(seg);
+    words += w;
+  }
+  if (current.length) chunks.push(current);
+  return chunks;
+}
+
+export function findingsSchema(phases) {
+  return {
+    type: 'object',
+    properties: {
+      findings: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            category: { type: 'string', enum: CATEGORY_IDS },
+            phase: { type: 'string', enum: phases },
+            text: { type: 'string', description: 'One discrete finding, a single clear sentence or two.' },
+            quote: { type: 'string', description: 'Short verbatim quote from the transcript supporting this finding.' },
+            segmentIds: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['category', 'phase', 'text', 'quote', 'segmentIds'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['findings'],
+    additionalProperties: false,
+  };
+}
+
+export function buildMessages({ session, segments }) {
+  const phases = sessionPhases(session);
+  const units = (session.units ?? []).map((u) => `${u.unit}${u.role ? ` (${u.role})` : ''}`).join(', ') || 'not recorded';
+  const categories = CATEGORIES.map((c) => `- "${c.id}" = ${c.label}`).join('\n');
+  const system = `You analyse the live transcript of a fire brigade After Action Review (AAR) meeting and extract discrete findings.
+
+Incident: ${session.incident.title || 'untitled'} — ${session.incident.type || 'unknown type'}, ${session.incident.date || 'date unknown'}, ${session.incident.location || 'location unknown'}.
+Attending units: ${units}.
+Incident phases discussed: ${phases.join(', ')}. "${GENERAL_PHASE}" is the bucket for anything not tied to one phase.
+
+Classify every finding into exactly one category:
+${categories}
+
+Transcript reality: this is usually a single room microphone with many speakers, so words are garbled. Fix obvious mis-hearings from context (e.g. "be a operators" → "BA operators"). Mark names or figures you are not sure of with "(unclear)". Keep Australian fire-service terminology exactly as used: BA, BACO, Cat 1, Cat 6, 38 mm, 65 mm, OCC, FRNSW, SCC, appliance, fireground, talkgroup.
+
+Rules:
+- Each finding is one discrete point, written as a clear standalone sentence (or two) a brigade member could read cold.
+- Ignore small talk, jokes, scheduling chatter and the facilitator's process talk ("let's move on to suppression").
+- Each transcript segment is prefixed with its id like [s12]. Every finding must include the segment ids it came from in segmentIds, and a short verbatim quote in quote.
+- Use the segment's tagged phase as a hint, but assign the phase the content is actually about.
+- If a chunk contains nothing of substance, return an empty findings array.
+
+Respond with a JSON object: {"findings": [{"category", "phase", "text", "quote", "segmentIds"}]}.`;
+
+  const lines = segments.map((seg) => {
+    const time = seg.t != null ? ` ${fmtClock(seg.t)}` : '';
+    const speaker = seg.speaker ? ` ${seg.speaker}:` : '';
+    return `[${seg.id}]${time} (${seg.phase})${speaker} ${seg.text}`;
+  });
+  const user = `Extract findings from these transcript segments:\n\n${lines.join('\n')}`;
+  return [
+    { role: 'system', content: system },
+    { role: 'user', content: user },
+  ];
+}
+
+/** Map a raw model finding into a session finding, clamping bad values. */
+export function toFinding(raw, session, segmentPool) {
+  const phases = sessionPhases(session);
+  const validIds = new Set(segmentPool.map((s) => s.id));
+  return createFinding({
+    category: CATEGORY_IDS.includes(raw.category) ? raw.category : 'happened',
+    phase: phases.includes(raw.phase) ? raw.phase : GENERAL_PHASE,
+    text: String(raw.text ?? '').trim(),
+    quote: String(raw.quote ?? '').trim(),
+    segmentIds: (Array.isArray(raw.segmentIds) ? raw.segmentIds : []).filter((id) => validIds.has(id)),
+    source: 'ai',
+  });
+}
+
+/**
+ * Run extraction over `segments` in chunks. Returns the new findings
+ * (not yet deduped). onProgress(done, total) fires per chunk.
+ */
+export async function extractFromSegments({ session, segments, settings, onProgress = () => {}, fetchImpl = globalThis.fetch }) {
+  const usable = segments.filter((s) => s.text.trim());
+  if (!usable.length) return [];
+  const phases = sessionPhases(session);
+  const schema = findingsSchema(phases);
+  const chunks = chunkSegments(usable);
+  const findings = [];
+  let done = 0;
+  for (const chunk of chunks) {
+    const result = await chatJson({
+      settings,
+      deployment: settings.llmDeployment,
+      messages: buildMessages({ session, segments: chunk }),
+      schema,
+      schemaName: 'aar_findings',
+      fetchImpl,
+    });
+    for (const raw of result?.findings ?? []) {
+      const f = toFinding(raw, session, usable);
+      if (f.text) findings.push(f);
+    }
+    onProgress(++done, chunks.length);
+  }
+  return findings;
+}

--- a/aar-studio/js/lib/llm.js
+++ b/aar-studio/js/lib/llm.js
@@ -1,0 +1,117 @@
+// Azure OpenAI chat-completions client (Azure AI Foundry deployments).
+// Browser → Azure directly; the api-key comes from settings (localStorage).
+// Pure fetch — loadable under node for tests.
+//
+// Structured output strategy: try response_format json_schema (strict);
+// a 400 means the api-version/model doesn't support it, so fall back to
+// json_object, then to free-form + JSON extraction. temperature/max_tokens
+// are never sent so reasoning models work unchanged.
+
+export class LlmError extends Error {
+  constructor(message, { hint = '', status = null, cause = null } = {}) {
+    super(message);
+    this.name = 'LlmError';
+    this.hint = hint;
+    this.status = status;
+    this.cause = cause;
+  }
+}
+
+export function chatUrl(settings, deployment) {
+  const endpoint = String(settings.llmEndpoint ?? '').trim().replace(/\/+$/, '');
+  if (!endpoint) throw new LlmError('No Azure OpenAI endpoint configured', { hint: 'Open Settings and set your Foundry/Azure OpenAI endpoint, e.g. https://myresource.openai.azure.com' });
+  if (!deployment) throw new LlmError('No deployment configured', { hint: 'Open Settings and set the chat deployment name (e.g. gpt-4o or gpt-4.1-mini).' });
+  const apiVersion = settings.apiVersion || '2024-10-21';
+  return `${endpoint}/openai/deployments/${encodeURIComponent(deployment)}/chat/completions?api-version=${encodeURIComponent(apiVersion)}`;
+}
+
+async function post(url, key, body, fetchImpl) {
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'api-key': key },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new LlmError('Could not reach the Azure OpenAI endpoint', {
+      hint: 'Network or CORS failure. Check the endpoint URL is correct (https://<resource>.openai.azure.com), that you are online, and that nothing (VPN/firewall) blocks *.openai.azure.com. Azure OpenAI allows browser calls by default — a CORS error usually means the URL or api-version is wrong.',
+      cause: err,
+    });
+  }
+  if (!res.ok) {
+    let detail = '';
+    try { detail = (await res.json())?.error?.message ?? ''; } catch { /* not json */ }
+    const hints = {
+      401: 'The api-key was rejected. Re-copy Key 1/Key 2 from the Azure portal for this resource.',
+      403: 'Access denied — the key may be for a different resource, or the resource has network restrictions blocking the browser.',
+      404: 'Deployment not found. Check the deployment name (not the model name) and the api-version.',
+      429: 'Rate limited — the deployment is out of quota. Wait a moment or raise the deployment TPM.',
+    };
+    const err = new LlmError(`Azure OpenAI returned ${res.status}${detail ? `: ${detail}` : ''}`, { hint: hints[res.status] ?? '', status: res.status });
+    throw err;
+  }
+  return res.json();
+}
+
+/** Strip ``` fences / prose and return the first JSON object in `text`. */
+export function extractJsonObject(text) {
+  const s = String(text ?? '');
+  const fenced = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidates = [fenced?.[1], s, s.slice(s.indexOf('{'), s.lastIndexOf('}') + 1)];
+  for (const c of candidates) {
+    if (!c) continue;
+    try { return JSON.parse(c.trim()); } catch { /* try next */ }
+  }
+  throw new LlmError('The model reply was not valid JSON', { hint: 'Try again, or use a deployment that supports structured outputs.' });
+}
+
+/**
+ * Run a chat completion that must return a JSON object.
+ * @returns {Promise<object>} parsed JSON content
+ */
+export async function chatJson({ settings, deployment, messages, schema, schemaName = 'result', fetchImpl = globalThis.fetch }) {
+  const key = String(settings.llmKey ?? '').trim();
+  if (!key) throw new LlmError('No Azure OpenAI key configured', { hint: 'Open Settings and paste an api-key for the resource. Keys are stored in this browser only.' });
+  const url = chatUrl(settings, deployment);
+
+  const attempts = [];
+  if (schema) attempts.push({ type: 'json_schema', json_schema: { name: schemaName, strict: true, schema } });
+  attempts.push({ type: 'json_object' });
+  attempts.push(null); // free-form, parse manually
+
+  let lastErr = null;
+  for (const responseFormat of attempts) {
+    const body = { messages };
+    if (responseFormat) body.response_format = responseFormat;
+    try {
+      const data = await post(url, key, body, fetchImpl);
+      const content = data?.choices?.[0]?.message?.content;
+      if (!content) throw new LlmError('Empty completion from the model');
+      return responseFormat ? JSON.parse(content) : extractJsonObject(content);
+    } catch (err) {
+      lastErr = err;
+      // Only a 400 (unsupported response_format / schema) warrants falling
+      // back; auth, network and rate-limit errors won't improve by retrying.
+      if (!(err instanceof LlmError) || err.status !== 400) throw err;
+    }
+  }
+  throw lastErr;
+}
+
+/** Cheap round-trip used by the Settings "Test connection" button. */
+export async function testConnection(settings, fetchImpl = globalThis.fetch) {
+  const result = await chatJson({
+    settings,
+    deployment: settings.llmDeployment,
+    messages: [
+      { role: 'system', content: 'Reply with a JSON object exactly like {"ok": true}.' },
+      { role: 'user', content: 'ping' },
+    ],
+    schema: { type: 'object', properties: { ok: { type: 'boolean' } }, required: ['ok'], additionalProperties: false },
+    schemaName: 'ping',
+    fetchImpl,
+  });
+  if (result?.ok !== true) throw new LlmError('Unexpected reply from the model');
+  return true;
+}

--- a/aar-studio/js/lib/model.js
+++ b/aar-studio/js/lib/model.js
@@ -1,0 +1,102 @@
+// Session data model: factories, constants and import validation. Pure.
+
+import { uid } from './text.js';
+
+export const SCHEMA_VERSION = 1;
+export const GENERAL_PHASE = 'General';
+export const DEFAULT_PHASES = ['Arrival', 'Rescue', 'Suppression', 'Overhaul'];
+
+export const CATEGORIES = [
+  { id: 'happened', label: 'What happened', short: 'Happened' },
+  { id: 'well', label: 'What went well', short: 'Went well' },
+  { id: 'didnt', label: "What didn't go well", short: "Didn't go well" },
+  { id: 'next', label: 'What would we do next time', short: 'Next time' },
+];
+export const CATEGORY_IDS = CATEGORIES.map((c) => c.id);
+
+export function categoryLabel(id) {
+  return CATEGORIES.find((c) => c.id === id)?.label ?? id;
+}
+
+export const INCIDENT_TYPES = [
+  'Structure Fire', 'Bush/Grass Fire', 'Motor Vehicle Accident',
+  'Storm/Flood', 'HAZMAT', 'Search/Rescue', 'Other',
+];
+
+export function createSession(partial = {}) {
+  const now = new Date().toISOString();
+  return {
+    id: uid(),
+    schemaVersion: SCHEMA_VERSION,
+    createdAt: now,
+    updatedAt: now,
+    incident: { title: '', date: '', location: '', type: '' },
+    aar: { date: '', location: '', facilitator: '' },
+    units: [],
+    phases: [...DEFAULT_PHASES],
+    currentPhase: GENERAL_PHASE,
+    segments: [],
+    findings: [],
+    speakers: {},
+    report: null,
+    ...partial,
+  };
+}
+
+export function createSegment({ t = null, speaker = '', text = '', phase = GENERAL_PHASE, source = 'paste' } = {}) {
+  return { id: uid(), t, speaker, text, phase, source, analysed: false };
+}
+
+export function createFinding({ category, phase = GENERAL_PHASE, text = '', quote = '', segmentIds = [], source = 'manual' }) {
+  if (!CATEGORY_IDS.includes(category)) category = 'happened';
+  return { id: uid(), category, phase, text, quote, segmentIds, source, createdAt: new Date().toISOString() };
+}
+
+/** Phases available for tagging: configured phases + the implicit General bucket. */
+export function sessionPhases(session) {
+  const phases = (session.phases ?? []).filter(Boolean);
+  return phases.includes(GENERAL_PHASE) ? phases : [...phases, GENERAL_PHASE];
+}
+
+/** Display name for a (possibly diarised) speaker, via the rename map. */
+export function speakerName(session, raw) {
+  return (raw && session.speakers?.[raw]) || raw || 'Unknown';
+}
+
+/**
+ * Validate + normalise an imported session object. Throws on structural
+ * problems; fills gaps so older/hand-edited exports still load.
+ */
+export function normaliseSession(obj) {
+  if (!obj || typeof obj !== 'object') throw new Error('Not a session object');
+  if (obj.schemaVersion != null && obj.schemaVersion > SCHEMA_VERSION) {
+    throw new Error(`Session schemaVersion ${obj.schemaVersion} is newer than this app supports (${SCHEMA_VERSION})`);
+  }
+  const base = createSession();
+  const s = {
+    ...base,
+    ...obj,
+    id: typeof obj.id === 'string' && obj.id ? obj.id : base.id,
+    schemaVersion: SCHEMA_VERSION,
+    incident: { ...base.incident, ...(obj.incident ?? {}) },
+    aar: { ...base.aar, ...(obj.aar ?? {}) },
+    units: Array.isArray(obj.units) ? obj.units.map((u) => ({ unit: String(u.unit ?? ''), role: String(u.role ?? '') })) : [],
+    phases: Array.isArray(obj.phases) && obj.phases.length ? obj.phases.map(String).filter((p) => p && p !== GENERAL_PHASE) : [...DEFAULT_PHASES],
+    speakers: obj.speakers && typeof obj.speakers === 'object' ? { ...obj.speakers } : {},
+    report: obj.report && typeof obj.report === 'object' ? obj.report : null,
+  };
+  s.segments = (Array.isArray(obj.segments) ? obj.segments : []).map((seg) => ({
+    ...createSegment(), ...seg,
+    id: seg.id || uid(),
+    text: String(seg.text ?? ''),
+    analysed: Boolean(seg.analysed),
+  }));
+  s.findings = (Array.isArray(obj.findings) ? obj.findings : []).map((f) => ({
+    ...createFinding({ category: f.category }), ...f,
+    id: f.id || uid(),
+    category: CATEGORY_IDS.includes(f.category) ? f.category : 'happened',
+    segmentIds: Array.isArray(f.segmentIds) ? f.segmentIds : [],
+  }));
+  if (!sessionPhases(s).includes(s.currentPhase)) s.currentPhase = GENERAL_PHASE;
+  return s;
+}

--- a/aar-studio/js/lib/reportGen.js
+++ b/aar-studio/js/lib/reportGen.js
@@ -1,0 +1,164 @@
+// AI report generation: turn the curated findings (plus session context)
+// into the full report structure. Uses the optional report deployment when
+// configured, falling back to the live-extraction deployment.
+
+import { chatJson } from './llm.js';
+import { CATEGORIES, sessionPhases, GENERAL_PHASE } from './model.js';
+import { emptyReport } from './exports.js';
+
+export function reportSchema(phases) {
+  const str = { type: 'string' };
+  const strArr = { type: 'array', items: str };
+  return {
+    type: 'object',
+    properties: {
+      headline: { ...str, description: 'Incident title for the report header' },
+      contextBar: { ...str, description: 'One line on the property/context, shown on the red bar' },
+      stats: {
+        type: 'array',
+        description: '4-6 key figures',
+        items: {
+          type: 'object',
+          properties: { value: str, label: str },
+          required: ['value', 'label'],
+          additionalProperties: false,
+        },
+      },
+      snapshot: { ...strArr, description: '1-2 short narrative paragraphs describing the incident' },
+      phases: {
+        type: 'array',
+        description: 'One entry per incident phase, in order',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', enum: phases },
+            happened: { ...str, description: 'Short narrative of what happened in this phase' },
+            well: { ...strArr, description: 'What went well — bullet sentences' },
+            didnt: { ...strArr, description: "What didn't go well / lessons — bullet sentences" },
+          },
+          required: ['name', 'happened', 'well', 'didnt'],
+          additionalProperties: false,
+        },
+      },
+      themes: {
+        type: 'array',
+        description: '0-3 cross-cutting theme sections',
+        items: {
+          type: 'object',
+          properties: { title: str, body: str },
+          required: ['title', 'body'],
+          additionalProperties: false,
+        },
+      },
+      recommendations: { ...strArr, description: 'Consolidated recommendations, most important first' },
+      actions: { ...strArr, description: 'Exactly the top 3 actions' },
+      assessment: { ...str, description: 'Overall assessment paragraph' },
+      caveat: { ...str, description: 'Verification caveat for the footer' },
+    },
+    required: ['headline', 'contextBar', 'stats', 'snapshot', 'phases', 'themes', 'recommendations', 'actions', 'assessment', 'caveat'],
+    additionalProperties: false,
+  };
+}
+
+export function buildReportMessages(session) {
+  const phases = sessionPhases(session);
+  const units = (session.units ?? []).map((u) => `- ${u.unit}: ${u.role}`).join('\n') || '- not recorded';
+  const findingLines = (session.findings ?? []).map((f) => {
+    const cat = CATEGORIES.find((c) => c.id === f.category)?.label ?? f.category;
+    const quote = f.quote ? ` (quote: "${f.quote}")` : '';
+    return `- [${f.phase} | ${cat}] ${f.text}${quote}`;
+  }).join('\n');
+
+  const system = `You write the After Action Review report for a fire brigade incident, working from the curated findings of the AAR meeting.
+
+Audience: brigade members and district staff. Tone: plain, direct, operational — no corporate filler. Keep Australian fire-service terminology exactly as used (BA, BACO, Cat 1, Cat 6, 38 mm, 65 mm, OCC, FRNSW, SCC, appliance, fireground). Keep "(unclear)" markers from findings — do not invent specifics to replace them.
+
+Produce a JSON report with this structure and style:
+- headline: the incident title, tightened if needed.
+- contextBar: one line describing the property/context and key constraints.
+- stats: 4-6 punchy figures drawn ONLY from the findings (value like "8" or "~1000", short uppercase-friendly label). Include "0 injuries"-style stats only if supported by the findings.
+- snapshot: 1-2 paragraphs telling the incident story.
+- phases: one entry per phase, in this order: ${phases.join(', ')}. Each has a short "happened" narrative plus "well" and "didnt" bullet lists. Write bullets as "Bold lead. Supporting detail." — a 3-8 word lead sentence, then the detail. Use the ${GENERAL_PHASE} entry for material not tied to one phase; leave fields empty if a phase genuinely has nothing.
+- themes: 0-3 cross-cutting sections (e.g. logistics aftermath) for material that spans phases; empty array if none warranted.
+- recommendations: consolidated, deduplicated, most important first, each actionable.
+- actions: exactly the top 3 actions, each one sentence, imperative.
+- assessment: an honest overall paragraph — what the job says about the brigades, and the single most important lesson.
+- caveat: a verification footer noting the source (AAR meeting transcript) and that names/callsigns/figures should be verified before wider distribution.
+
+Base everything on the findings. Do not introduce facts that are not in them.`;
+
+  const user = `Incident: ${session.incident.title || 'untitled'}
+Type: ${session.incident.type || 'unknown'} | Date: ${session.incident.date || 'unknown'} | Location: ${session.incident.location || 'unknown'}
+AAR: ${session.aar.date || 'date unknown'}${session.aar.location ? `, ${session.aar.location}` : ''}${session.aar.facilitator ? ` (facilitator: ${session.aar.facilitator})` : ''}
+
+Attending units:
+${units}
+
+Findings (${session.findings?.length ?? 0}):
+${findingLines || '- none recorded'}
+
+Write the report JSON now.`;
+
+  return [
+    { role: 'system', content: system },
+    { role: 'user', content: user },
+  ];
+}
+
+/** Clamp/align a raw model report onto the session's report shape. */
+export function normaliseReport(raw, session) {
+  const base = emptyReport(session);
+  const r = raw && typeof raw === 'object' ? raw : {};
+  const str = (v, fallback = '') => (typeof v === 'string' ? v.trim() : fallback);
+  const strArr = (v) => (Array.isArray(v) ? v.map((x) => str(x)).filter(Boolean) : []);
+
+  const byName = new Map((Array.isArray(r.phases) ? r.phases : []).map((p) => [p?.name, p]));
+  // Keep the session's phase order; include a General entry only if the model
+  // put something in it.
+  const phases = base.phases.map((p) => {
+    const m = byName.get(p.name) ?? {};
+    return { name: p.name, happened: str(m.happened), well: strArr(m.well), didnt: strArr(m.didnt) };
+  });
+  const general = byName.get(GENERAL_PHASE);
+  if (general && (str(general.happened) || strArr(general.well).length || strArr(general.didnt).length)) {
+    phases.push({ name: GENERAL_PHASE, happened: str(general.happened), well: strArr(general.well), didnt: strArr(general.didnt) });
+  }
+
+  const actions = strArr(r.actions).slice(0, 3);
+  while (actions.length < 3) actions.push('');
+
+  return {
+    headline: str(r.headline, base.headline),
+    contextBar: str(r.contextBar),
+    stats: (Array.isArray(r.stats) ? r.stats : [])
+      .map((s) => ({ value: str(s?.value), label: str(s?.label) }))
+      .filter((s) => s.value || s.label)
+      .slice(0, 6),
+    snapshot: strArr(r.snapshot),
+    phases,
+    themes: (Array.isArray(r.themes) ? r.themes : [])
+      .map((t) => ({ title: str(t?.title), body: str(t?.body) }))
+      .filter((t) => t.title || t.body)
+      .slice(0, 3),
+    recommendations: strArr(r.recommendations),
+    actions,
+    assessment: str(r.assessment),
+    caveat: str(r.caveat, base.caveat),
+  };
+}
+
+/** Generate the report from the session's findings. Returns a report object. */
+export async function generateReport({ session, settings, fetchImpl = globalThis.fetch }) {
+  if (!session.findings?.length) {
+    throw new Error('No findings to build a report from — run the AI analysis (or add findings) first');
+  }
+  const raw = await chatJson({
+    settings,
+    deployment: settings.reportDeployment || settings.llmDeployment,
+    messages: buildReportMessages(session),
+    schema: reportSchema(sessionPhases(session)),
+    schemaName: 'aar_report',
+    fetchImpl,
+  });
+  return normaliseReport(raw, session);
+}

--- a/aar-studio/js/lib/text.js
+++ b/aar-studio/js/lib/text.js
@@ -1,0 +1,46 @@
+// Pure text helpers shared by lib modules, views and tests. No DOM.
+
+export function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function countWords(text) {
+  const m = String(text ?? '').trim().match(/\S+/g);
+  return m ? m.length : 0;
+}
+
+export function slugify(s) {
+  return String(s ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'session';
+}
+
+/** Seconds → "m:ss" or "h:mm:ss". Null-safe. */
+export function fmtClock(seconds) {
+  if (seconds == null || Number.isNaN(seconds)) return '';
+  const s = Math.max(0, Math.round(seconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = String(s % 60).padStart(2, '0');
+  return h > 0 ? `${h}:${String(m).padStart(2, '0')}:${sec}` : `${m}:${sec}`;
+}
+
+/** "m:ss", "mm:ss", "h:mm:ss", "00:01:05.250" → seconds (or null). */
+export function parseClock(s) {
+  const m = String(s ?? '').trim().match(/^(?:(\d{1,2}):)?(\d{1,2}):(\d{2})(?:[.,](\d{1,3}))?$/);
+  if (!m) return null;
+  const [, h, min, sec] = m;
+  return (h ? Number(h) * 3600 : 0) + Number(min) * 60 + Number(sec);
+}
+
+export function uid() {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  return 'id-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+}

--- a/aar-studio/js/lib/transcriptParser.js
+++ b/aar-studio/js/lib/transcriptParser.js
@@ -1,0 +1,102 @@
+// Transcript paste parser. Pure — returns plain {speaker, t, text} rows;
+// the caller turns them into session segments.
+//
+// Supported formats (auto-detected):
+//  - "teams-docx": the format you get copying a Teams transcript out of the
+//    meeting recap / exported DOCX — a header line "Name   m:ss" (name, then
+//    whitespace, then a timestamp ending the line) followed by one or more
+//    text lines, until the next header.
+//  - "vtt": WEBVTT cue files, including <v Speaker>text</v> voice spans.
+//  - "speaker-colon": "Name: text" lines.
+//  - "plain": fallback — each paragraph becomes one unattributed row.
+
+import { parseClock } from './text.js';
+
+const TEAMS_HEADER = /^(.{1,80}?)\s+(\d{1,2}:\d{2}(?::\d{2})?)\s*$/;
+const SPEAKER_COLON = /^([A-Za-z][\w .,'()/-]{0,60}?):\s+(\S.*)$/;
+const VTT_TIMING = /^(\d{1,2}:)?\d{1,2}:\d{2}[.,]\d{1,3}\s+-->\s+/;
+
+export function parseTranscript(raw) {
+  const text = String(raw ?? '').replace(/\r\n?/g, '\n').replace(/ /g, ' ');
+  const lines = text.split('\n');
+  if (/^﻿?WEBVTT\b/.test(text.trimStart())) return { format: 'vtt', rows: parseVtt(lines) };
+  const teams = parseTeamsDocx(lines);
+  if (teams.length >= 2) return { format: 'teams-docx', rows: teams };
+  const colon = parseSpeakerColon(lines);
+  if (colon.length >= 2) return { format: 'speaker-colon', rows: colon };
+  return { format: 'plain', rows: parsePlain(text) };
+}
+
+function parseTeamsDocx(lines) {
+  const rows = [];
+  let current = null;
+  for (const line of lines) {
+    const m = line.match(TEAMS_HEADER);
+    // A header must have a non-numeric name part, otherwise "10:30" alone or
+    // bare timestamps would match.
+    if (m && /[A-Za-z]/.test(m[1])) {
+      if (current?.text) rows.push(current);
+      current = { speaker: m[1].trim(), t: parseClock(m[2]), text: '' };
+    } else if (current && line.trim()) {
+      current.text += (current.text ? ' ' : '') + line.trim();
+    } else if (current && !line.trim() && current.text) {
+      rows.push(current);
+      current = null;
+    }
+  }
+  if (current?.text) rows.push(current);
+  return rows;
+}
+
+function parseSpeakerColon(lines) {
+  const rows = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const m = line.match(SPEAKER_COLON);
+    // Limit "names" to a few words so prose containing a colon doesn't match.
+    if (m && m[1].trim().split(/\s+/).length <= 5) {
+      rows.push({ speaker: m[1].trim(), t: null, text: m[2].trim() });
+    } else if (rows.length) {
+      rows[rows.length - 1].text += ' ' + line.trim(); // continuation line
+    }
+  }
+  return rows;
+}
+
+function parseVtt(lines) {
+  const rows = [];
+  let t = null;
+  let pending = [];
+  const flush = () => {
+    if (!pending.length) return;
+    for (const textLine of pending) {
+      const v = textLine.match(/^<v\s+([^>]+)>\s*(.*?)(?:<\/v>)?$/);
+      if (v) rows.push({ speaker: v[1].trim(), t, text: v[2].trim() });
+      else if (rows.length && rows[rows.length - 1].t === t) rows[rows.length - 1].text += ' ' + textLine;
+      else rows.push({ speaker: '', t, text: textLine });
+    }
+    pending = [];
+  };
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (VTT_TIMING.test(line)) {
+      flush();
+      t = parseClock(line.split('-->')[0].trim());
+    } else if (!line) {
+      flush();
+      t = null;
+    } else if (t != null && !/^WEBVTT/.test(line) && !/^NOTE\b/.test(line)) {
+      pending.push(line);
+    }
+  }
+  flush();
+  return rows.filter((r) => r.text);
+}
+
+function parsePlain(text) {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\s*\n\s*/g, ' ').trim())
+    .filter(Boolean)
+    .map((p) => ({ speaker: '', t: null, text: p }));
+}

--- a/aar-studio/js/main.js
+++ b/aar-studio/js/main.js
@@ -1,0 +1,64 @@
+// App bootstrap: hash router, nav, re-render policy.
+
+import { h, clear } from './ui.js';
+import * as store from './store.js';
+import { openSettingsDialog } from './settings.js';
+import * as home from './views/home.js';
+import * as setup from './views/setup.js';
+import * as capture from './views/capture.js';
+import * as board from './views/board.js';
+import * as review from './views/review.js';
+import * as report from './views/report.js';
+
+const ROUTES = [
+  { hash: '#/home', label: 'Sessions', view: home, always: true },
+  { hash: '#/setup', label: 'Setup', view: setup },
+  { hash: '#/capture', label: 'Capture', view: capture },
+  { hash: '#/board', label: 'Board', view: board },
+  { hash: '#/review', label: 'Review', view: review },
+  { hash: '#/report', label: 'Report', view: report },
+];
+
+const main = document.getElementById('view');
+const nav = document.getElementById('nav');
+const sessionLabel = document.getElementById('session-label');
+
+function currentRoute() {
+  return ROUTES.find((r) => r.hash === location.hash) ?? ROUTES[0];
+}
+
+function renderNav() {
+  const session = store.getSession();
+  clear(nav);
+  for (const r of ROUTES) {
+    nav.append(h('a', {
+      href: r.hash,
+      class: `nav__link${currentRoute() === r ? ' nav__link--active' : ''}${!r.always && !session ? ' nav__link--disabled' : ''}`,
+    }, r.label));
+  }
+  nav.append(h('button', { class: 'nav__settings', title: 'Settings', 'aria-label': 'Settings', onclick: openSettingsDialog }, '⚙'));
+  sessionLabel.textContent = session ? (session.incident.title || 'Untitled AAR') : '';
+}
+
+function render() {
+  const route = currentRoute();
+  if (!route.always && !store.getSession()) {
+    location.hash = '#/home';
+    return;
+  }
+  renderNav();
+  clear(main);
+  route.view.render(main);
+}
+
+window.addEventListener('hashchange', render);
+
+store.subscribe((reason) => {
+  // Field-level edits use {silent:true}; everything else re-renders the view.
+  if (reason === 'save-error') return;
+  render();
+});
+
+store.resumeLastSession();
+if (!location.hash) location.hash = store.getSession() ? '#/board' : '#/home';
+render();

--- a/aar-studio/js/settings.js
+++ b/aar-studio/js/settings.js
@@ -13,7 +13,7 @@ export const DEFAULT_SETTINGS = {
   llmDeployment: '',        // live extraction, e.g. gpt-4o / gpt-4.1-mini
   reportDeployment: '',     // optional larger model for report generation
   apiVersion: '2024-10-21',
-  // Azure AI Speech (Stage 4 — live audio)
+  // Azure AI Speech (live listen)
   speechKey: '',
   speechRegion: 'australiaeast',
   language: 'en-AU',
@@ -102,7 +102,7 @@ export function openSettingsDialog() {
       field('Report deployment (optional)', text('reportDeployment', { placeholder: 'gpt-4o' }), 'Falls back to the chat deployment when empty.'),
       field('API version', text('apiVersion', { placeholder: DEFAULT_SETTINGS.apiVersion })),
       h('div', { class: 'settings__row' }, testBtn, status),
-      h('h3', {}, 'Azure AI Speech (live audio — coming in Stage 4)'),
+      h('h3', {}, 'Azure AI Speech (live listen)'),
       field('Speech key', (inputs.speechKey = h('input', { type: 'password', value: s.speechKey, autocomplete: 'off' }))),
       field('Region', text('speechRegion', { placeholder: 'australiaeast' })),
       field('Language', text('language', { placeholder: 'en-AU' })),

--- a/aar-studio/js/settings.js
+++ b/aar-studio/js/settings.js
@@ -1,0 +1,120 @@
+// Azure configuration: stored in localStorage only, edited via a <dialog>.
+// Calls go browser → Azure directly; there is no backend to hold keys.
+
+import { h, clear, toast } from './ui.js';
+import { testConnection, LlmError } from './lib/llm.js';
+
+const KEY = 'aarstudio.settings';
+
+export const DEFAULT_SETTINGS = {
+  // Azure OpenAI (Azure AI Foundry deployment)
+  llmEndpoint: '',
+  llmKey: '',
+  llmDeployment: '',        // live extraction, e.g. gpt-4o / gpt-4.1-mini
+  reportDeployment: '',     // optional larger model for report generation
+  apiVersion: '2024-10-21',
+  // Azure AI Speech (Stage 4 — live audio)
+  speechKey: '',
+  speechRegion: 'australiaeast',
+  language: 'en-AU',
+  diarization: true,
+};
+
+export function getSettings() {
+  try {
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(localStorage.getItem(KEY) ?? '{}') };
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function saveSettings(settings) {
+  localStorage.setItem(KEY, JSON.stringify(settings));
+}
+
+function field(labelText, input, help) {
+  return h('label', { class: 'field' },
+    h('span', { class: 'field__label' }, labelText),
+    input,
+    help ? h('span', { class: 'field__help' }, help) : null,
+  );
+}
+
+export function openSettingsDialog() {
+  const s = getSettings();
+  const dialog = document.getElementById('settings-dialog');
+  clear(dialog);
+
+  const inputs = {};
+  const text = (key, attrs = {}) => (inputs[key] = h('input', { type: 'text', value: s[key], ...attrs }));
+
+  const status = h('div', { class: 'settings__status' });
+
+  const collect = () => ({
+    ...s,
+    llmEndpoint: inputs.llmEndpoint.value.trim(),
+    llmKey: inputs.llmKey.value.trim(),
+    llmDeployment: inputs.llmDeployment.value.trim(),
+    reportDeployment: inputs.reportDeployment.value.trim(),
+    apiVersion: inputs.apiVersion.value.trim() || DEFAULT_SETTINGS.apiVersion,
+    speechKey: inputs.speechKey.value.trim(),
+    speechRegion: inputs.speechRegion.value.trim() || DEFAULT_SETTINGS.speechRegion,
+    language: inputs.language.value.trim() || DEFAULT_SETTINGS.language,
+    diarization: inputs.diarization.checked,
+  });
+
+  const testBtn = h('button', {
+    class: 'btn',
+    type: 'button',
+    onclick: async () => {
+      status.textContent = 'Testing…';
+      status.className = 'settings__status';
+      testBtn.disabled = true;
+      try {
+        await testConnection(collect());
+        status.textContent = '✓ Connected — the deployment answered correctly.';
+        status.classList.add('settings__status--ok');
+      } catch (err) {
+        const hint = err instanceof LlmError && err.hint ? ` ${err.hint}` : '';
+        status.textContent = `✗ ${err.message}.${hint}`;
+        status.classList.add('settings__status--err');
+      } finally {
+        testBtn.disabled = false;
+      }
+    },
+  }, 'Test connection');
+
+  dialog.append(
+    h('form', {
+      method: 'dialog',
+      onsubmit: () => {
+        saveSettings(collect());
+        toast('Settings saved (this browser only)');
+      },
+    },
+      h('h2', {}, 'Settings'),
+      h('p', { class: 'settings__note' },
+        'Keys are stored in this browser’s localStorage only and sent directly to your Azure resources. Use scoped keys you can rotate.'),
+      h('h3', {}, 'Azure OpenAI (Foundry)'),
+      field('Endpoint', text('llmEndpoint', { placeholder: 'https://myresource.openai.azure.com', autocomplete: 'off' })),
+      field('API key', (inputs.llmKey = h('input', { type: 'password', value: s.llmKey, autocomplete: 'off' }))),
+      field('Chat deployment (live extraction)', text('llmDeployment', { placeholder: 'gpt-4.1-mini' })),
+      field('Report deployment (optional)', text('reportDeployment', { placeholder: 'gpt-4o' }), 'Falls back to the chat deployment when empty.'),
+      field('API version', text('apiVersion', { placeholder: DEFAULT_SETTINGS.apiVersion })),
+      h('div', { class: 'settings__row' }, testBtn, status),
+      h('h3', {}, 'Azure AI Speech (live audio — coming in Stage 4)'),
+      field('Speech key', (inputs.speechKey = h('input', { type: 'password', value: s.speechKey, autocomplete: 'off' }))),
+      field('Region', text('speechRegion', { placeholder: 'australiaeast' })),
+      field('Language', text('language', { placeholder: 'en-AU' })),
+      h('label', { class: 'field field--check' },
+        (inputs.diarization = h('input', { type: 'checkbox', checked: s.diarization })),
+        h('span', {}, 'Diarization (separate speakers)'),
+      ),
+      h('div', { class: 'dialog__actions' },
+        h('button', { class: 'btn', type: 'button', onclick: () => dialog.close() }, 'Cancel'),
+        h('button', { class: 'btn btn--primary', type: 'submit' }, 'Save'),
+      ),
+    ),
+  );
+  dialog.showModal();
+}

--- a/aar-studio/js/store.js
+++ b/aar-studio/js/store.js
@@ -1,0 +1,128 @@
+// Current-session store: one localStorage key per session, autosave on every
+// mutation, tiny pub/sub so views can re-render on structural changes.
+
+import { createSession, normaliseSession } from './lib/model.js';
+
+const SESSION_PREFIX = 'aarstudio.session.';
+const LAST_KEY = 'aarstudio.lastSession';
+
+let current = null;
+const listeners = new Set();
+
+export function getSession() {
+  return current;
+}
+
+export function subscribe(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function notify(reason) {
+  for (const fn of listeners) fn(reason);
+}
+
+function persist() {
+  if (!current) return;
+  current.updatedAt = new Date().toISOString();
+  try {
+    localStorage.setItem(SESSION_PREFIX + current.id, JSON.stringify(current));
+    localStorage.setItem(LAST_KEY, current.id);
+  } catch (err) {
+    console.error('autosave failed', err);
+    notify('save-error');
+  }
+}
+
+/**
+ * Mutate the current session and autosave.
+ * silent=true skips re-render notification (use for per-keystroke field
+ * edits where the input is already the source of truth on screen).
+ */
+export function update(mutator, { silent = false, reason = 'session' } = {}) {
+  if (!current) return;
+  mutator(current);
+  persist();
+  if (!silent) notify(reason);
+}
+
+export function newSession() {
+  current = createSession();
+  persist();
+  notify('session-loaded');
+  return current;
+}
+
+export function openSession(id) {
+  const raw = localStorage.getItem(SESSION_PREFIX + id);
+  if (!raw) throw new Error('Session not found');
+  current = normaliseSession(JSON.parse(raw));
+  localStorage.setItem(LAST_KEY, current.id);
+  notify('session-loaded');
+  return current;
+}
+
+export function closeSession() {
+  current = null;
+  localStorage.removeItem(LAST_KEY);
+  notify('session-loaded');
+}
+
+export function resumeLastSession() {
+  const id = localStorage.getItem(LAST_KEY);
+  if (!id) return null;
+  try {
+    return openSession(id);
+  } catch {
+    return null;
+  }
+}
+
+export function listSessions() {
+  const sessions = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key?.startsWith(SESSION_PREFIX)) continue;
+    try {
+      const s = JSON.parse(localStorage.getItem(key));
+      sessions.push({
+        id: s.id,
+        title: s.incident?.title || 'Untitled AAR',
+        incidentDate: s.incident?.date || '',
+        updatedAt: s.updatedAt || '',
+        findings: s.findings?.length ?? 0,
+        segments: s.segments?.length ?? 0,
+      });
+    } catch {
+      // skip corrupt entries
+    }
+  }
+  return sessions.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''));
+}
+
+export function deleteSession(id) {
+  localStorage.removeItem(SESSION_PREFIX + id);
+  if (current?.id === id) {
+    current = null;
+    localStorage.removeItem(LAST_KEY);
+  }
+  notify('session-loaded');
+}
+
+/** Import a session from exported JSON text; opens it as current. */
+export function importSessionJson(text) {
+  const session = normaliseSession(JSON.parse(text));
+  // Avoid clobbering an existing different session that shares the id.
+  const existing = localStorage.getItem(SESSION_PREFIX + session.id);
+  if (existing && JSON.parse(existing).updatedAt !== session.updatedAt) {
+    session.id = createSession().id;
+  }
+  current = session;
+  persist();
+  notify('session-loaded');
+  return current;
+}
+
+export function exportSessionJson(session = current) {
+  return JSON.stringify(session, null, 2);
+}

--- a/aar-studio/js/ui.js
+++ b/aar-studio/js/ui.js
@@ -1,0 +1,60 @@
+// Small DOM helpers. Browser only — keep js/lib free of this.
+
+/** Hyperscript-ish element builder. attrs: class, dataset, on* handlers, etc. */
+export function h(tag, attrs = {}, ...children) {
+  const el = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs ?? {})) {
+    if (v == null || v === false) continue;
+    if (k === 'class') el.className = v;
+    else if (k === 'dataset') Object.assign(el.dataset, v);
+    else if (k.startsWith('on') && typeof v === 'function') el.addEventListener(k.slice(2), v);
+    else if (k === 'value') el.value = v;
+    else if (k === 'checked' || k === 'disabled' || k === 'selected' || k === 'open') el[k] = Boolean(v);
+    else el.setAttribute(k, v === true ? '' : v);
+  }
+  for (const child of children.flat(Infinity)) {
+    if (child == null || child === false) continue;
+    el.append(child.nodeType ? child : document.createTextNode(child));
+  }
+  return el;
+}
+
+export function clear(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+  return node;
+}
+
+let toastHost = null;
+export function toast(message, kind = 'info', ms = 3500) {
+  if (!toastHost) {
+    toastHost = h('div', { class: 'toast-host', role: 'status', 'aria-live': 'polite' });
+    document.body.append(toastHost);
+  }
+  const t = h('div', { class: `toast toast--${kind}` }, message);
+  toastHost.append(t);
+  setTimeout(() => {
+    t.classList.add('toast--out');
+    setTimeout(() => t.remove(), 400);
+  }, ms);
+}
+
+export function download(filename, text, mime = 'text/plain') {
+  const url = URL.createObjectURL(new Blob([text], { type: mime }));
+  const a = h('a', { href: url, download: filename });
+  document.body.append(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
+
+export function pickFile(accept) {
+  return new Promise((resolve) => {
+    const input = h('input', { type: 'file', accept });
+    input.addEventListener('change', () => resolve(input.files?.[0] ?? null));
+    input.click();
+  });
+}
+
+export function confirmDanger(message) {
+  return window.confirm(message);
+}

--- a/aar-studio/js/views/board.js
+++ b/aar-studio/js/views/board.js
@@ -1,0 +1,125 @@
+// Live findings board: four category columns, phase chips and filter,
+// quick add, edit/delete, fullscreen high-contrast Present mode.
+
+import { h, toast } from '../ui.js';
+import * as store from '../store.js';
+import { CATEGORIES, sessionPhases, createFinding } from '../lib/model.js';
+import { analyseNow } from './capture.js';
+
+let phaseFilter = null; // null = all
+
+function findingCard(f, phases) {
+  const card = h('div', { class: `finding finding--${f.category}` });
+  const body = h('div', { class: 'finding__text' }, f.text);
+  card.append(
+    body,
+    h('div', { class: 'finding__meta' },
+      h('span', { class: 'chip chip--phase' }, f.phase),
+      f.source === 'ai' ? h('span', { class: 'chip chip--ai', title: f.quote ? `“${f.quote}”` : 'AI extracted' }, 'AI') : null,
+      h('span', { class: 'finding__tools' },
+        h('button', { class: 'icon-btn', title: 'Edit', 'aria-label': 'Edit finding', onclick: () => editInline() }, '✎'),
+        h('button', { class: 'icon-btn', title: 'Delete', 'aria-label': 'Delete finding', onclick: () => store.update((s) => { s.findings = s.findings.filter((x) => x.id !== f.id); }, { reason: 'findings' }) }, '✕'),
+      ),
+    ),
+    f.quote ? h('div', { class: 'finding__quote' }, `“${f.quote}”`) : null,
+  );
+
+  function editInline() {
+    const textArea = h('textarea', { rows: 3 }, f.text);
+    const catSel = h('select', {}, CATEGORIES.map((c) => h('option', { value: c.id, selected: c.id === f.category }, c.label)));
+    const phaseSel = h('select', {}, phases.map((p) => h('option', { value: p, selected: p === f.phase }, p)));
+    const editor = h('div', { class: 'finding__editor' },
+      textArea,
+      h('div', { class: 'btn-row' },
+        catSel, phaseSel,
+        h('button', { class: 'btn btn--small btn--primary', onclick: () => {
+          store.update((s) => {
+            const target = s.findings.find((x) => x.id === f.id);
+            if (target) Object.assign(target, { text: textArea.value.trim(), category: catSel.value, phase: phaseSel.value });
+          }, { reason: 'findings' });
+        } }, 'Save'),
+        h('button', { class: 'btn btn--small', onclick: () => store.update(() => {}, { reason: 'findings' }) }, 'Cancel'),
+      ),
+    );
+    card.replaceChildren(editor);
+    textArea.focus();
+  }
+
+  return card;
+}
+
+function quickAdd(phases) {
+  const input = h('input', { type: 'text', placeholder: 'Quick-add a finding…', class: 'quick-add__input' });
+  const catSel = h('select', {}, CATEGORIES.map((c) => h('option', { value: c.id }, c.label)));
+  const phaseSel = h('select', {}, phases.map((p) => h('option', { value: p, selected: p === store.getSession().currentPhase }, p)));
+  const add = () => {
+    if (!input.value.trim()) return;
+    store.update((s) => {
+      s.findings.push(createFinding({ category: catSel.value, phase: phaseSel.value, text: input.value.trim(), source: 'manual' }));
+    }, { reason: 'findings' });
+    toast('Finding added');
+  };
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') add(); });
+  return h('div', { class: 'quick-add' }, input, catSel, phaseSel, h('button', { class: 'btn btn--primary', onclick: add }, 'Add'));
+}
+
+function togglePresent() {
+  const on = document.body.classList.toggle('present');
+  if (on) document.documentElement.requestFullscreen?.().catch(() => {});
+  else if (document.fullscreenElement) document.exitFullscreen?.().catch(() => {});
+}
+
+export function render(container) {
+  const session = store.getSession();
+  const phases = sessionPhases(session);
+  if (phaseFilter && !phases.includes(phaseFilter)) phaseFilter = null;
+  const status = h('span', { class: 'muted' });
+
+  const visible = session.findings.filter((f) => !phaseFilter || f.phase === phaseFilter);
+
+  const filterChips = h('div', { class: 'phase-filter' },
+    h('button', { class: `chip chip--filter${phaseFilter === null ? ' chip--on' : ''}`, onclick: () => { phaseFilter = null; rerender(); } }, `All (${session.findings.length})`),
+    phases.map((p) => {
+      const n = session.findings.filter((f) => f.phase === p).length;
+      return h('button', { class: `chip chip--filter${phaseFilter === p ? ' chip--on' : ''}`, onclick: () => { phaseFilter = phaseFilter === p ? null : p; rerender(); } }, `${p} (${n})`);
+    }),
+  );
+
+  const columns = h('div', { class: 'board' }, CATEGORIES.map((cat) => {
+    const items = visible.filter((f) => f.category === cat.id);
+    return h('div', { class: `board__col board__col--${cat.id}` },
+      h('div', { class: 'board__head' }, h('span', {}, cat.label), h('span', { class: 'board__count' }, String(items.length))),
+      h('div', { class: 'board__cards' },
+        items.length ? items.map((f) => findingCard(f, phases)) : h('p', { class: 'muted board__empty' }, '—'),
+      ),
+    );
+  }));
+
+  function rerender() {
+    // local UI state (filter) changed — re-render without touching the store
+    container.replaceChildren();
+    render(container);
+  }
+
+  container.append(
+    h('div', { class: 'board-toolbar' },
+      h('h1', {}, 'Findings board'),
+      h('div', { class: 'btn-row' },
+        h('button', { class: 'btn', onclick: () => analyseNow(status) }, '✨ Analyse new transcript'),
+        status,
+        h('button', { class: 'btn', onclick: togglePresent, title: 'Fullscreen high-contrast view for the projector' }, '⛶ Present'),
+      ),
+    ),
+    filterChips,
+    quickAdd(phases),
+    columns,
+    h('button', { class: 'present-exit btn', onclick: togglePresent }, 'Exit present mode (Esc)'),
+  );
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && document.body.classList.contains('present')) document.body.classList.remove('present');
+});
+document.addEventListener('fullscreenchange', () => {
+  if (!document.fullscreenElement) document.body.classList.remove('present');
+});

--- a/aar-studio/js/views/board.js
+++ b/aar-studio/js/views/board.js
@@ -4,7 +4,7 @@
 import { h, toast } from '../ui.js';
 import * as store from '../store.js';
 import { CATEGORIES, sessionPhases, createFinding } from '../lib/model.js';
-import { analyseNow } from './capture.js';
+import { analyseNow } from '../analyse.js';
 
 let phaseFilter = null; // null = all
 

--- a/aar-studio/js/views/capture.js
+++ b/aar-studio/js/views/capture.js
@@ -1,52 +1,13 @@
-// Capture: phase clicker, transcript ingest (paste path now; live audio
-// arrives in Stage 4), segment list, AI analysis.
+// Capture: live listen (mic / shared tab / file via Azure AI Speech),
+// phase clicker, transcript paste ingest, segment list, AI analysis.
 
-import { h, toast, confirmDanger } from '../ui.js';
+import { h, toast, confirmDanger, pickFile } from '../ui.js';
 import * as store from '../store.js';
-import { getSettings } from '../settings.js';
+import { analyseNow } from '../analyse.js';
+import * as live from '../audio/live.js';
 import { sessionPhases, createSegment, speakerName, GENERAL_PHASE } from '../lib/model.js';
 import { parseTranscript } from '../lib/transcriptParser.js';
-import { extractFromSegments } from '../lib/extraction.js';
-import { dedupeFindings } from '../lib/dedupe.js';
-import { LlmError } from '../lib/llm.js';
 import { fmtClock } from '../lib/text.js';
-
-let analysing = false;
-
-/** Run extraction over un-analysed segments; shared with the Board view. */
-export async function analyseNow(statusEl) {
-  if (analysing) return;
-  const session = store.getSession();
-  const pending = session.segments.filter((seg) => !seg.analysed && seg.text.trim());
-  if (!pending.length) {
-    toast('Nothing new to analyse — all segments are already processed');
-    return;
-  }
-  analysing = true;
-  const setStatus = (msg) => { if (statusEl) statusEl.textContent = msg; };
-  try {
-    setStatus(`Analysing ${pending.length} segment(s)…`);
-    const found = await extractFromSegments({
-      session,
-      segments: pending,
-      settings: getSettings(),
-      onProgress: (done, total) => setStatus(`Analysing… chunk ${done}/${total}`),
-    });
-    const { added, skipped } = dedupeFindings(session.findings, found);
-    store.update((s) => {
-      s.findings.push(...added);
-      const ids = new Set(pending.map((seg) => seg.id));
-      for (const seg of s.segments) if (ids.has(seg.id)) seg.analysed = true;
-    }, { reason: 'findings' });
-    toast(`${added.length} new finding(s)${skipped.length ? `, ${skipped.length} duplicate(s) skipped` : ''}`);
-  } catch (err) {
-    const hint = err instanceof LlmError && err.hint ? ` — ${err.hint}` : '';
-    toast(`${err.message}${hint}`, 'error', 8000);
-    setStatus('');
-  } finally {
-    analysing = false;
-  }
-}
 
 function ingestPaste(textarea) {
   const raw = textarea.value;
@@ -68,6 +29,78 @@ function ingestPaste(textarea) {
   toast(`Added ${rows.length} segment(s) (detected format: ${format})`);
 }
 
+function audioPanel(status) {
+  const ls = live.getState();
+  const backupCheck = h('input', { type: 'checkbox', checked: true });
+
+  const startBtn = (kind, onclick) => h('button', {
+    class: 'btn btn--big',
+    disabled: ls.status !== 'idle',
+    onclick,
+  }, `${live.SOURCES[kind].icon} ${live.SOURCES[kind].label}`);
+
+  const idleControls = h('div', {},
+    h('div', { class: 'btn-row' },
+      startBtn('mic', () => live.start('mic', { backup: backupCheck.checked })),
+      startBtn('display', () => live.start('display', { backup: backupCheck.checked })),
+      startBtn('file', async () => {
+        const file = await pickFile('audio/*');
+        if (file) live.start('file', { file });
+      }),
+    ),
+    h('label', { class: 'field field--check' }, backupCheck,
+      h('span', {}, 'Keep a local backup recording (offered as a download when you stop)')),
+    h('p', { class: 'muted' },
+      'Room microphone is the primary mode — one mic, many speakers; diarization and language are set in ⚙ Settings. For a Teams meeting, share the meeting tab and tick “Share audio”.'),
+  );
+
+  // Live elements updated directly by the controller (no re-render per frame)
+  const meterBar = h('div', { class: 'meter__bar' });
+  const meter = h('div', { class: 'meter', title: 'Input level' }, meterBar);
+  const elapsed = h('span', { class: 'live__elapsed' }, '0:00');
+  const interimEl = h('div', { class: 'live__interim', 'aria-live': 'off' });
+  const stateText = ls.status === 'starting' ? 'Connecting…'
+    : ls.status === 'stopping' ? 'Stopping…'
+    : `Listening — ${live.SOURCES[ls.source]?.label ?? ''}`;
+
+  const liveControls = h('div', { class: 'live' },
+    h('div', { class: 'live__row' },
+      h('span', { class: 'live__dot', 'aria-hidden': 'true' }),
+      h('span', { class: 'live__state' }, stateText),
+      elapsed,
+      meter,
+      h('button', { class: 'btn btn--danger', disabled: ls.status !== 'listening', onclick: () => live.stop() }, '■ Stop listening'),
+    ),
+    interimEl,
+    ls.recording ? h('p', { class: 'muted' }, '● Local backup recording in progress') : null,
+  );
+
+  const panel = h('section', { class: 'panel' },
+    h('h2', {}, 'Live listen'),
+    ls.status === 'idle' ? idleControls : liveControls,
+    ls.recordingUrl && ls.status === 'idle'
+      ? h('p', {}, h('a', { class: 'btn', href: ls.recordingUrl, download: ls.recordingName }, '⬇ Download backup recording'))
+      : null,
+    ls.error ? h('p', { class: 'live__error', role: 'alert' }, ls.error) : null,
+  );
+
+  // High-frequency updates touch the DOM directly; anything structural
+  // (status flips, errors) re-renders the view, which rebuilds this panel
+  // from live.getState() and re-registers this listener with fresh nodes.
+  live.setUiListener((event, s) => {
+    if (event === 'level') {
+      meterBar.style.setProperty('--level', String(Math.min(1, s.level * 6)));
+      if (s.startedAt) elapsed.textContent = fmtClock((Date.now() - s.startedAt) / 1000);
+    } else if (event === 'interim') {
+      interimEl.textContent = s.interim ? `${s.interimSpeaker ? s.interimSpeaker + ': ' : ''}${s.interim}…` : '';
+    } else {
+      store.update(() => {}, { reason: 'live' });
+    }
+  });
+
+  return panel;
+}
+
 export function render(container) {
   const session = store.getSession();
   const phases = sessionPhases(session);
@@ -79,7 +112,7 @@ export function render(container) {
       onclick: () => {
         store.update((s) => { s.currentPhase = p; }, { reason: 'phase' });
         // Phase change is an extraction trigger.
-        analyseNow(status);
+        analyseNow(status, { quiet: true });
       },
     }, p)),
   );
@@ -101,7 +134,7 @@ export function render(container) {
         ),
         h('span', { class: 'segment__text' }, seg.text),
       )))
-    : h('p', { class: 'muted' }, 'No transcript yet. Paste one below, or wait for live audio capture (Stage 4).');
+    : h('p', { class: 'muted' }, 'No transcript yet. Start live listening above, or paste a transcript below.');
 
   container.append(
     h('h1', {}, 'Live capture'),
@@ -110,16 +143,7 @@ export function render(container) {
       h('p', { class: 'muted' }, 'Click the phase as the room moves through it — new segments are tagged with it, and changing phase triggers an analysis pass.'),
       phaseButtons,
     ),
-    h('section', { class: 'panel' },
-      h('h2', {}, 'Audio'),
-      h('p', { class: 'muted' },
-        'Room microphone, shared Teams tab audio and uploaded recordings land in Stage 4 (Azure AI Speech with diarization). Until then, use the transcript paste below — the AI analysis pipeline is identical.'),
-      h('div', { class: 'btn-row' },
-        h('button', { class: 'btn', disabled: true, title: 'Coming in Stage 4' }, '🎙 Room microphone'),
-        h('button', { class: 'btn', disabled: true, title: 'Coming in Stage 4' }, '🖥 Share Teams tab audio'),
-        h('button', { class: 'btn', disabled: true, title: 'Coming in Stage 4' }, '📂 Upload audio file'),
-      ),
-    ),
+    audioPanel(status),
     h('section', { class: 'panel' },
       h('h2', {}, 'Paste a transcript'),
       pasteBox,
@@ -142,4 +166,10 @@ export function render(container) {
       ) : null,
     ),
   );
+
+  // Auto-scroll the transcript to the latest segment while listening.
+  if (live.getState().status === 'listening' && segments.length) {
+    const list = container.querySelector('.segments');
+    if (list) list.scrollTop = list.scrollHeight;
+  }
 }

--- a/aar-studio/js/views/capture.js
+++ b/aar-studio/js/views/capture.js
@@ -1,0 +1,145 @@
+// Capture: phase clicker, transcript ingest (paste path now; live audio
+// arrives in Stage 4), segment list, AI analysis.
+
+import { h, toast, confirmDanger } from '../ui.js';
+import * as store from '../store.js';
+import { getSettings } from '../settings.js';
+import { sessionPhases, createSegment, speakerName, GENERAL_PHASE } from '../lib/model.js';
+import { parseTranscript } from '../lib/transcriptParser.js';
+import { extractFromSegments } from '../lib/extraction.js';
+import { dedupeFindings } from '../lib/dedupe.js';
+import { LlmError } from '../lib/llm.js';
+import { fmtClock } from '../lib/text.js';
+
+let analysing = false;
+
+/** Run extraction over un-analysed segments; shared with the Board view. */
+export async function analyseNow(statusEl) {
+  if (analysing) return;
+  const session = store.getSession();
+  const pending = session.segments.filter((seg) => !seg.analysed && seg.text.trim());
+  if (!pending.length) {
+    toast('Nothing new to analyse — all segments are already processed');
+    return;
+  }
+  analysing = true;
+  const setStatus = (msg) => { if (statusEl) statusEl.textContent = msg; };
+  try {
+    setStatus(`Analysing ${pending.length} segment(s)…`);
+    const found = await extractFromSegments({
+      session,
+      segments: pending,
+      settings: getSettings(),
+      onProgress: (done, total) => setStatus(`Analysing… chunk ${done}/${total}`),
+    });
+    const { added, skipped } = dedupeFindings(session.findings, found);
+    store.update((s) => {
+      s.findings.push(...added);
+      const ids = new Set(pending.map((seg) => seg.id));
+      for (const seg of s.segments) if (ids.has(seg.id)) seg.analysed = true;
+    }, { reason: 'findings' });
+    toast(`${added.length} new finding(s)${skipped.length ? `, ${skipped.length} duplicate(s) skipped` : ''}`);
+  } catch (err) {
+    const hint = err instanceof LlmError && err.hint ? ` — ${err.hint}` : '';
+    toast(`${err.message}${hint}`, 'error', 8000);
+    setStatus('');
+  } finally {
+    analysing = false;
+  }
+}
+
+function ingestPaste(textarea) {
+  const raw = textarea.value;
+  if (!raw.trim()) {
+    toast('Paste a transcript first', 'error');
+    return;
+  }
+  const { format, rows } = parseTranscript(raw);
+  if (!rows.length) {
+    toast('Could not find any transcript lines in the pasted text', 'error');
+    return;
+  }
+  store.update((s) => {
+    for (const row of rows) {
+      s.segments.push(createSegment({ t: row.t, speaker: row.speaker, text: row.text, phase: GENERAL_PHASE, source: 'paste' }));
+    }
+  }, { reason: 'segments' });
+  textarea.value = '';
+  toast(`Added ${rows.length} segment(s) (detected format: ${format})`);
+}
+
+export function render(container) {
+  const session = store.getSession();
+  const phases = sessionPhases(session);
+  const status = h('span', { class: 'muted' });
+
+  const phaseButtons = h('div', { class: 'phase-clicker', role: 'group', 'aria-label': 'Current phase' },
+    phases.map((p) => h('button', {
+      class: `phase-btn${session.currentPhase === p ? ' phase-btn--active' : ''}`,
+      onclick: () => {
+        store.update((s) => { s.currentPhase = p; }, { reason: 'phase' });
+        // Phase change is an extraction trigger.
+        analyseNow(status);
+      },
+    }, p)),
+  );
+
+  const pasteBox = h('textarea', {
+    class: 'paste-box',
+    rows: 8,
+    placeholder: 'Paste a Teams transcript here…\nSupported: the DOCX copy format ("Name   m:ss" then text), "Name: text" lines, or WEBVTT.',
+  });
+
+  const segments = session.segments;
+  const segmentList = segments.length
+    ? h('ol', { class: 'segments' }, segments.slice(-200).map((seg) => h('li', { class: 'segment' },
+        h('span', { class: 'segment__meta' },
+          seg.t != null ? h('span', { class: 'segment__time' }, fmtClock(seg.t)) : null,
+          seg.speaker ? h('span', { class: 'segment__speaker' }, speakerName(session, seg.speaker)) : null,
+          h('span', { class: `chip chip--phase` }, seg.phase),
+          seg.analysed ? h('span', { class: 'chip chip--done', title: 'Included in an AI analysis pass' }, '✓ analysed') : null,
+        ),
+        h('span', { class: 'segment__text' }, seg.text),
+      )))
+    : h('p', { class: 'muted' }, 'No transcript yet. Paste one below, or wait for live audio capture (Stage 4).');
+
+  container.append(
+    h('h1', {}, 'Live capture'),
+    h('section', { class: 'panel' },
+      h('h2', {}, 'Current phase'),
+      h('p', { class: 'muted' }, 'Click the phase as the room moves through it — new segments are tagged with it, and changing phase triggers an analysis pass.'),
+      phaseButtons,
+    ),
+    h('section', { class: 'panel' },
+      h('h2', {}, 'Audio'),
+      h('p', { class: 'muted' },
+        'Room microphone, shared Teams tab audio and uploaded recordings land in Stage 4 (Azure AI Speech with diarization). Until then, use the transcript paste below — the AI analysis pipeline is identical.'),
+      h('div', { class: 'btn-row' },
+        h('button', { class: 'btn', disabled: true, title: 'Coming in Stage 4' }, '🎙 Room microphone'),
+        h('button', { class: 'btn', disabled: true, title: 'Coming in Stage 4' }, '🖥 Share Teams tab audio'),
+        h('button', { class: 'btn', disabled: true, title: 'Coming in Stage 4' }, '📂 Upload audio file'),
+      ),
+    ),
+    h('section', { class: 'panel' },
+      h('h2', {}, 'Paste a transcript'),
+      pasteBox,
+      h('div', { class: 'btn-row' },
+        h('button', { class: 'btn btn--primary', onclick: () => ingestPaste(pasteBox) }, 'Parse & add segments'),
+        h('button', { class: 'btn', onclick: () => analyseNow(status) }, '✨ Analyse with AI now'),
+        status,
+      ),
+    ),
+    h('section', { class: 'panel' },
+      h('h2', {}, `Transcript (${segments.length} segments)`),
+      segmentList,
+      segments.length ? h('div', { class: 'btn-row' },
+        h('a', { class: 'btn btn--primary', href: '#/board' }, 'Open the live board →'),
+        h('button', { class: 'btn btn--danger', onclick: () => {
+          if (confirmDanger('Clear ALL transcript segments? Findings are kept.')) {
+            store.update((s) => { s.segments = []; }, { reason: 'segments' });
+          }
+        } }, 'Clear transcript'),
+      ) : null,
+    ),
+  );
+}

--- a/aar-studio/js/views/home.js
+++ b/aar-studio/js/views/home.js
@@ -1,0 +1,68 @@
+// Home: session list, new session, JSON import, sample session.
+
+import { h, toast, download, pickFile, confirmDanger } from '../ui.js';
+import * as store from '../store.js';
+import { sessionFilename } from '../lib/exports.js';
+
+async function loadSample() {
+  const res = await fetch('./data/sample-session.json');
+  if (!res.ok) throw new Error(`Sample not found (${res.status})`);
+  store.importSessionJson(await res.text());
+  location.hash = '#/board';
+  toast('Wamboin sample session loaded — explore Board, Review and Report');
+}
+
+async function importJson() {
+  const file = await pickFile('application/json,.json');
+  if (!file) return;
+  try {
+    store.importSessionJson(await file.text());
+    location.hash = '#/setup';
+    toast('Session imported');
+  } catch (err) {
+    toast(`Import failed: ${err.message}`, 'error');
+  }
+}
+
+export function render(container) {
+  const sessions = store.listSessions();
+
+  container.append(
+    h('section', { class: 'hero' },
+      h('h1', {}, 'AAR Studio'),
+      h('p', {}, 'Facilitate, live-present and package After Action Reviews for fire brigade incidents. Everything stays in this browser; AI calls go straight to your Azure resources.'),
+      h('div', { class: 'hero__actions' },
+        h('button', { class: 'btn btn--primary btn--big', onclick: () => { store.newSession(); location.hash = '#/setup'; } }, 'New AAR session'),
+        h('button', { class: 'btn btn--big', onclick: importJson }, 'Import session JSON'),
+        h('button', { class: 'btn btn--big', onclick: () => loadSample().catch((e) => toast(e.message, 'error')) }, 'Load Wamboin sample'),
+      ),
+    ),
+    h('section', {},
+      h('h2', {}, 'Saved sessions'),
+      sessions.length
+        ? h('table', { class: 'table' },
+            h('thead', {}, h('tr', {}, h('th', {}, 'Incident'), h('th', {}, 'Incident date'), h('th', {}, 'Findings'), h('th', {}, 'Segments'), h('th', {}, 'Updated'), h('th', {}, ''))),
+            h('tbody', {}, sessions.map((s) => h('tr', {},
+              h('td', {}, h('a', { href: '#/board', onclick: () => store.openSession(s.id) }, s.title)),
+              h('td', {}, s.incidentDate),
+              h('td', {}, String(s.findings)),
+              h('td', {}, String(s.segments)),
+              h('td', {}, s.updatedAt ? new Date(s.updatedAt).toLocaleString() : ''),
+              h('td', { class: 'table__actions' },
+                h('button', { class: 'btn btn--small', onclick: () => {
+                  const session = store.openSession(s.id);
+                  download(sessionFilename(session, 'session', 'json'), store.exportSessionJson(session), 'application/json');
+                } }, 'Export'),
+                h('button', { class: 'btn btn--small btn--danger', onclick: () => {
+                  if (confirmDanger(`Delete "${s.title}"? This cannot be undone (export it first if unsure).`)) {
+                    store.deleteSession(s.id);
+                    toast('Session deleted');
+                  }
+                } }, 'Delete'),
+              ),
+            ))),
+          )
+        : h('p', { class: 'muted' }, 'No sessions yet. Start one, or load the Wamboin sample to see a finished AAR.'),
+    ),
+  );
+}

--- a/aar-studio/js/views/report.js
+++ b/aar-studio/js/views/report.js
@@ -1,0 +1,116 @@
+// Report studio: every report field editable with a live preview, plus
+// exports (snapshot HTML, Markdown summary, session JSON, print-to-PDF).
+// AI report generation arrives in Stage 3 (remaining part).
+
+import { h, toast, download } from '../ui.js';
+import * as store from '../store.js';
+import { emptyReport, renderSnapshotHtml, renderMarkdown, sessionFilename } from '../lib/exports.js';
+
+function field(labelText, input) {
+  return h('label', { class: 'field' }, h('span', { class: 'field__label' }, labelText), input);
+}
+
+export function render(container) {
+  const session = store.getSession();
+
+  if (!session.report) {
+    container.append(
+      h('h1', {}, 'Report'),
+      h('section', { class: 'panel' },
+        h('p', {}, 'No report yet for this session.'),
+        h('div', { class: 'btn-row' },
+          h('button', { class: 'btn btn--primary', onclick: () => {
+            store.update((s) => { s.report = emptyReport(s); }, { reason: 'report' });
+          } }, 'Start from a blank template'),
+          h('button', { class: 'btn', disabled: true, title: 'AI report generation lands with Stage 3 — see aar-studio/docs/PLAN.md' }, '✨ Generate with AI (coming soon)'),
+        ),
+        h('p', { class: 'muted' }, 'The blank template is pre-filled from your session setup; AI generation from the curated findings is the next stage. Load the Wamboin sample from Home to see a finished report.'),
+      ),
+    );
+    return;
+  }
+
+  const r = session.report;
+  const preview = h('iframe', { class: 'report-preview', title: 'Report preview' });
+  const refresh = () => { preview.srcdoc = renderSnapshotHtml(store.getSession()); };
+
+  // Every edit autosaves silently and refreshes the preview; no re-render so
+  // focus is preserved while typing.
+  const edit = (apply) => (e) => {
+    store.update((s) => apply(s.report, e.target.value), { silent: true });
+    refresh();
+  };
+  const lines = (value) => (value ?? []).join('\n');
+  const splitLines = (v) => v.split('\n').map((x) => x.trim()).filter(Boolean);
+  const paras = (value) => (value ?? []).join('\n\n');
+  const splitParas = (v) => v.split(/\n\s*\n/).map((x) => x.trim()).filter(Boolean);
+
+  const statsBody = h('tbody', {}, r.stats.map((stat, i) => h('tr', {},
+    h('td', {}, h('input', { type: 'text', value: stat.value, placeholder: '800', oninput: edit((rep, v) => { rep.stats[i].value = v; }) })),
+    h('td', {}, h('input', { type: 'text', value: stat.label, placeholder: 'L/min ground monitor — decisive', oninput: edit((rep, v) => { rep.stats[i].label = v; }) })),
+    h('td', {}, h('button', { class: 'icon-btn', onclick: () => store.update((s) => { s.report.stats.splice(i, 1); }, { reason: 'report' }) }, '✕')),
+  )));
+
+  const themeRows = r.themes.map((t, i) => h('div', { class: 'theme-row' },
+    h('input', { type: 'text', value: t.title, placeholder: 'Theme title', oninput: edit((rep, v) => { rep.themes[i].title = v; }) }),
+    h('textarea', { rows: 3, placeholder: 'Theme narrative', oninput: edit((rep, v) => { rep.themes[i].body = v; }) }, t.body),
+    h('button', { class: 'icon-btn', onclick: () => store.update((s) => { s.report.themes.splice(i, 1); }, { reason: 'report' }) }, '✕'),
+  ));
+
+  const phaseEditors = r.phases.map((p, i) => h('details', { class: 'phase-report', open: true },
+    h('summary', {}, p.name),
+    field('What happened (narrative)', h('textarea', { rows: 4, oninput: edit((rep, v) => { rep.phases[i].happened = v; }) }, p.happened)),
+    field('What went well (one bullet per line)', h('textarea', { rows: 4, oninput: (e) => { store.update((s) => { s.report.phases[i].well = splitLines(e.target.value); }, { silent: true }); refresh(); } }, lines(p.well))),
+    field("What didn't go well / lessons (one bullet per line)", h('textarea', { rows: 4, oninput: (e) => { store.update((s) => { s.report.phases[i].didnt = splitLines(e.target.value); }, { silent: true }); refresh(); } }, lines(p.didnt))),
+  ));
+
+  container.append(
+    h('div', { class: 'board-toolbar' },
+      h('h1', {}, 'Report'),
+      h('div', { class: 'btn-row' },
+        h('button', { class: 'btn btn--primary', onclick: () => download(sessionFilename(session, 'snapshot', 'html'), renderSnapshotHtml(store.getSession()), 'text/html') }, '⬇ Snapshot HTML'),
+        h('button', { class: 'btn', onclick: () => download(sessionFilename(session, 'summary', 'md'), renderMarkdown(store.getSession()), 'text/markdown') }, '⬇ Markdown'),
+        h('button', { class: 'btn', onclick: () => download(sessionFilename(session, 'session', 'json'), store.exportSessionJson(), 'application/json') }, '⬇ Session JSON'),
+        h('button', { class: 'btn', onclick: () => { preview.contentWindow?.print(); } }, '🖨 Print / PDF'),
+      ),
+    ),
+    h('div', { class: 'report-layout' },
+      h('div', { class: 'report-form' },
+        field('Headline', h('input', { type: 'text', value: r.headline, oninput: edit((rep, v) => { rep.headline = v; }) })),
+        field('Context / property bar (one line, shown on red)', h('textarea', { rows: 2, oninput: edit((rep, v) => { rep.contextBar = v; }) }, r.contextBar)),
+        h('fieldset', {},
+          h('legend', {}, 'Key stats (aim for 4–6)'),
+          h('table', { class: 'table' }, h('thead', {}, h('tr', {}, h('th', {}, 'Value'), h('th', {}, 'Label'), h('th'))), statsBody),
+          h('button', { class: 'btn btn--small', onclick: () => store.update((s) => { s.report.stats.push({ value: '', label: '' }); }, { reason: 'report' }) }, '+ Add stat'),
+        ),
+        field('Incident snapshot (paragraphs, blank line between)', h('textarea', { rows: 5, oninput: (e) => { store.update((s) => { s.report.snapshot = splitParas(e.target.value); }, { silent: true }); refresh(); } }, paras(r.snapshot))),
+        h('fieldset', {}, h('legend', {}, 'Per-phase detail'), phaseEditors),
+        h('fieldset', {},
+          h('legend', {}, 'Cross-cutting themes (0–3)'),
+          themeRows,
+          h('button', { class: 'btn btn--small', disabled: r.themes.length >= 3, onclick: () => store.update((s) => { s.report.themes.push({ title: '', body: '' }); }, { reason: 'report' }) }, '+ Add theme'),
+        ),
+        field('Consolidated recommendations (one per line)', h('textarea', { rows: 6, oninput: (e) => { store.update((s) => { s.report.recommendations = splitLines(e.target.value); }, { silent: true }); refresh(); } }, lines(r.recommendations))),
+        h('fieldset', {},
+          h('legend', {}, 'Top three actions'),
+          [0, 1, 2].map((i) => field(`Action ${i + 1}`, h('textarea', { rows: 2, oninput: edit((rep, v) => { rep.actions[i] = v; }) }, r.actions[i] ?? ''))),
+        ),
+        field('Overall assessment', h('textarea', { rows: 4, oninput: edit((rep, v) => { rep.assessment = v; }) }, r.assessment)),
+        field('Verification caveat (report footer)', h('textarea', { rows: 2, oninput: edit((rep, v) => { rep.caveat = v; }) }, r.caveat)),
+        h('div', { class: 'btn-row' },
+          h('button', { class: 'btn btn--danger', onclick: () => {
+            if (window.confirm('Discard the whole report? Findings and transcript are kept.')) {
+              store.update((s) => { s.report = null; }, { reason: 'report' });
+              toast('Report discarded');
+            }
+          } }, 'Discard report'),
+        ),
+      ),
+      h('div', { class: 'report-preview-pane' },
+        h('h2', {}, 'Live preview — one-page snapshot'),
+        preview,
+      ),
+    ),
+  );
+  refresh();
+}

--- a/aar-studio/js/views/report.js
+++ b/aar-studio/js/views/report.js
@@ -4,27 +4,57 @@
 
 import { h, toast, download } from '../ui.js';
 import * as store from '../store.js';
-import { emptyReport, renderSnapshotHtml, renderMarkdown, sessionFilename } from '../lib/exports.js';
+import { getSettings } from '../settings.js';
+import { emptyReport, renderSnapshotHtml, renderCombinedHtml, renderMarkdown, sessionFilename } from '../lib/exports.js';
+import { generateReport } from '../lib/reportGen.js';
+import { LlmError } from '../lib/llm.js';
 
 function field(labelText, input) {
   return h('label', { class: 'field' }, h('span', { class: 'field__label' }, labelText), input);
+}
+
+let generating = false;
+
+async function generate(statusEl) {
+  if (generating) return;
+  const session = store.getSession();
+  generating = true;
+  if (statusEl) statusEl.textContent = 'Generating report from the findings… (this can take a minute on a large model)';
+  try {
+    const report = await generateReport({ session, settings: getSettings() });
+    store.update((s) => { s.report = report; }, { reason: 'report' });
+    toast('Report generated — every field below is editable');
+  } catch (err) {
+    const hint = err instanceof LlmError && err.hint ? ` — ${err.hint}` : '';
+    toast(`${err.message}${hint}`, 'error', 8000);
+    if (statusEl) statusEl.textContent = '';
+  } finally {
+    generating = false;
+  }
 }
 
 export function render(container) {
   const session = store.getSession();
 
   if (!session.report) {
+    const status = h('p', { class: 'muted', role: 'status' });
+    const hasFindings = session.findings.length > 0;
     container.append(
       h('h1', {}, 'Report'),
       h('section', { class: 'panel' },
         h('p', {}, 'No report yet for this session.'),
         h('div', { class: 'btn-row' },
-          h('button', { class: 'btn btn--primary', onclick: () => {
+          h('button', {
+            class: 'btn btn--primary', disabled: !hasFindings,
+            title: hasFindings ? '' : 'Capture and analyse the discussion first — the report is built from the findings',
+            onclick: (e) => { e.target.disabled = true; generate(status).finally(() => { e.target.disabled = false; }); },
+          }, `✨ Generate with AI (${session.findings.length} findings)`),
+          h('button', { class: 'btn', onclick: () => {
             store.update((s) => { s.report = emptyReport(s); }, { reason: 'report' });
           } }, 'Start from a blank template'),
-          h('button', { class: 'btn', disabled: true, title: 'AI report generation lands with Stage 3 — see aar-studio/docs/PLAN.md' }, '✨ Generate with AI (coming soon)'),
         ),
-        h('p', { class: 'muted' }, 'The blank template is pre-filled from your session setup; AI generation from the curated findings is the next stage. Load the Wamboin sample from Home to see a finished report.'),
+        status,
+        h('p', { class: 'muted' }, 'Generation uses the report deployment from ⚙ Settings (falls back to the chat deployment). Load the Wamboin sample from Home to see a finished report.'),
       ),
     );
     return;
@@ -64,14 +94,26 @@ export function render(container) {
     field("What didn't go well / lessons (one bullet per line)", h('textarea', { rows: 4, oninput: (e) => { store.update((s) => { s.report.phases[i].didnt = splitLines(e.target.value); }, { silent: true }); refresh(); } }, lines(p.didnt))),
   ));
 
+  const transcriptCheck = h('input', { type: 'checkbox' });
+  const genStatus = h('span', { class: 'muted' });
+
   container.append(
     h('div', { class: 'board-toolbar' },
       h('h1', {}, 'Report'),
       h('div', { class: 'btn-row' },
         h('button', { class: 'btn btn--primary', onclick: () => download(sessionFilename(session, 'snapshot', 'html'), renderSnapshotHtml(store.getSession()), 'text/html') }, '⬇ Snapshot HTML'),
+        h('button', { class: 'btn', onclick: () => download(sessionFilename(session, 'report', 'html'), renderCombinedHtml(store.getSession(), { includeTranscript: transcriptCheck.checked }), 'text/html') }, '⬇ Combined report'),
+        h('label', { class: 'field field--check', title: 'Append the full transcript to the combined report' }, transcriptCheck, h('span', {}, '+ transcript')),
         h('button', { class: 'btn', onclick: () => download(sessionFilename(session, 'summary', 'md'), renderMarkdown(store.getSession()), 'text/markdown') }, '⬇ Markdown'),
         h('button', { class: 'btn', onclick: () => download(sessionFilename(session, 'session', 'json'), store.exportSessionJson(), 'application/json') }, '⬇ Session JSON'),
         h('button', { class: 'btn', onclick: () => { preview.contentWindow?.print(); } }, '🖨 Print / PDF'),
+        h('button', { class: 'btn', disabled: !session.findings.length, onclick: (e) => {
+          if (window.confirm('Regenerate the report with AI? Your current report (including manual edits) will be replaced.')) {
+            e.target.disabled = true;
+            generate(genStatus).finally(() => { e.target.disabled = false; });
+          }
+        } }, '✨ Regenerate'),
+        genStatus,
       ),
     ),
     h('div', { class: 'report-layout' },

--- a/aar-studio/js/views/review.js
+++ b/aar-studio/js/views/review.js
@@ -1,0 +1,94 @@
+// Review & edit: transcript text/phase/speaker editing, diarised speaker
+// renaming, full findings curation.
+
+import { h, toast } from '../ui.js';
+import * as store from '../store.js';
+import { CATEGORIES, sessionPhases, createFinding } from '../lib/model.js';
+import { fmtClock } from '../lib/text.js';
+
+function speakerPanel(session) {
+  const raw = [...new Set(session.segments.map((s) => s.speaker).filter(Boolean))];
+  if (!raw.length) return null;
+  return h('section', { class: 'panel' },
+    h('h2', {}, 'Speakers'),
+    h('p', { class: 'muted' }, 'Rename diarised speakers — the new name is used everywhere (board, report, exports).'),
+    h('table', { class: 'table' },
+      h('thead', {}, h('tr', {}, h('th', {}, 'Transcript name'), h('th', {}, 'Display as'))),
+      h('tbody', {}, raw.map((name) => h('tr', {},
+        h('td', {}, name),
+        h('td', {}, h('input', {
+          type: 'text', value: session.speakers[name] ?? '', placeholder: name,
+          oninput: (e) => store.update((s) => {
+            if (e.target.value.trim()) s.speakers[name] = e.target.value;
+            else delete s.speakers[name];
+          }, { silent: true }),
+        })),
+      ))),
+    ),
+  );
+}
+
+function transcriptPanel(session, phases) {
+  if (!session.segments.length) return null;
+  return h('section', { class: 'panel' },
+    h('h2', {}, `Transcript (${session.segments.length} segments)`),
+    h('div', { class: 'review-segments' }, session.segments.map((seg) => h('div', { class: 'review-segment' },
+      h('div', { class: 'review-segment__meta' },
+        seg.t != null ? h('span', { class: 'segment__time' }, fmtClock(seg.t)) : null,
+        h('input', {
+          type: 'text', class: 'review-segment__speaker', value: seg.speaker, placeholder: 'Speaker',
+          oninput: (e) => store.update((s) => { const t = s.segments.find((x) => x.id === seg.id); if (t) t.speaker = e.target.value; }, { silent: true }),
+        }),
+        h('select', {
+          onchange: (e) => store.update((s) => { const t = s.segments.find((x) => x.id === seg.id); if (t) t.phase = e.target.value; }, { silent: true }),
+        }, phases.map((p) => h('option', { value: p, selected: p === seg.phase }, p))),
+        h('button', { class: 'icon-btn', title: 'Delete segment', onclick: () => store.update((s) => { s.segments = s.segments.filter((x) => x.id !== seg.id); }, { reason: 'segments' }) }, '✕'),
+      ),
+      h('textarea', {
+        rows: 2,
+        oninput: (e) => store.update((s) => { const t = s.segments.find((x) => x.id === seg.id); if (t) t.text = e.target.value; }, { silent: true }),
+      }, seg.text),
+    ))),
+  );
+}
+
+function findingsPanel(session, phases) {
+  return h('section', { class: 'panel' },
+    h('h2', {}, `Findings (${session.findings.length})`),
+    h('div', { class: 'review-findings' }, session.findings.map((f) => h('div', { class: `review-finding review-finding--${f.category}` },
+      h('div', { class: 'review-finding__meta' },
+        h('select', {
+          onchange: (e) => store.update((s) => { const t = s.findings.find((x) => x.id === f.id); if (t) t.category = e.target.value; }, { silent: true }),
+        }, CATEGORIES.map((c) => h('option', { value: c.id, selected: c.id === f.category }, c.label))),
+        h('select', {
+          onchange: (e) => store.update((s) => { const t = s.findings.find((x) => x.id === f.id); if (t) t.phase = e.target.value; }, { silent: true }),
+        }, phases.map((p) => h('option', { value: p, selected: p === f.phase }, p))),
+        h('span', { class: `chip ${f.source === 'ai' ? 'chip--ai' : 'chip--manual'}` }, f.source),
+        h('button', { class: 'icon-btn', title: 'Delete finding', onclick: () => store.update((s) => { s.findings = s.findings.filter((x) => x.id !== f.id); }, { reason: 'findings' }) }, '✕'),
+      ),
+      h('textarea', {
+        rows: 2,
+        oninput: (e) => store.update((s) => { const t = s.findings.find((x) => x.id === f.id); if (t) t.text = e.target.value; }, { silent: true }),
+      }, f.text),
+      h('input', {
+        type: 'text', class: 'review-finding__quote', value: f.quote, placeholder: 'Verbatim quote (optional)',
+        oninput: (e) => store.update((s) => { const t = s.findings.find((x) => x.id === f.id); if (t) t.quote = e.target.value; }, { silent: true }),
+      }),
+    ))),
+    h('button', { class: 'btn', onclick: () => {
+      store.update((s) => { s.findings.push(createFinding({ category: 'happened', phase: s.currentPhase })); }, { reason: 'findings' });
+      toast('Empty finding added — fill it in');
+    } }, '+ Add finding'),
+  );
+}
+
+export function render(container) {
+  const session = store.getSession();
+  const phases = sessionPhases(session);
+  container.append(
+    h('h1', {}, 'Review & edit'),
+    speakerPanel(session),
+    findingsPanel(session, phases),
+    transcriptPanel(session, phases),
+  );
+}

--- a/aar-studio/js/views/setup.js
+++ b/aar-studio/js/views/setup.js
@@ -1,0 +1,76 @@
+// Session setup: incident, AAR meeting details, attending units, phases.
+
+import { h, toast } from '../ui.js';
+import * as store from '../store.js';
+import { INCIDENT_TYPES, GENERAL_PHASE } from '../lib/model.js';
+
+function field(labelText, input) {
+  return h('label', { class: 'field' }, h('span', { class: 'field__label' }, labelText), input);
+}
+
+// Field edits persist silently (autosave) without re-rendering, so typing
+// keeps focus. Structural edits (rows added/removed) re-render.
+function bind(getValue, apply) {
+  return {
+    oninput: (e) => store.update((s) => apply(s, e.target.value ?? getValue(e)), { silent: true }),
+  };
+}
+
+export function render(container) {
+  const s = store.getSession();
+
+  const text = (value, apply, attrs = {}) =>
+    h('input', { type: 'text', value, ...attrs, ...bind(() => value, apply) });
+
+  const unitsBody = h('tbody', {}, s.units.map((u, i) => h('tr', {},
+    h('td', {}, text(u.unit, (sess, v) => { sess.units[i].unit = v; }, { placeholder: 'Brigade / agency' })),
+    h('td', {}, text(u.role, (sess, v) => { sess.units[i].role = v; }, { placeholder: 'Role on the fireground' })),
+    h('td', {}, h('button', { class: 'btn btn--small btn--danger', onclick: () => store.update((sess) => sess.units.splice(i, 1)) }, '✕')),
+  )));
+
+  const phaseList = h('div', { class: 'phase-editor' },
+    s.phases.map((p, i) => h('div', { class: 'phase-editor__row' },
+      text(p, (sess, v) => { sess.phases[i] = v; }),
+      h('button', { class: 'btn btn--small btn--danger', title: 'Remove phase', onclick: () => store.update((sess) => sess.phases.splice(i, 1)) }, '✕'),
+    )),
+    h('div', { class: 'muted' }, `Plus an implicit “${GENERAL_PHASE}” bucket for anything not tied to a phase.`),
+  );
+
+  container.append(
+    h('h1', {}, 'Session setup'),
+    h('div', { class: 'form-grid' },
+      h('fieldset', {},
+        h('legend', {}, 'Incident'),
+        field('Title', text(s.incident.title, (sess, v) => { sess.incident.title = v; }, { placeholder: 'e.g. Wamboin Structure Fire — 412 Macs Reef Road' })),
+        field('Date', h('input', { type: 'date', value: s.incident.date, ...bind(null, (sess, v) => { sess.incident.date = v; }) })),
+        field('Location', text(s.incident.location, (sess, v) => { sess.incident.location = v; })),
+        field('Type', h('select', {
+          onchange: (e) => store.update((sess) => { sess.incident.type = e.target.value; }, { silent: true }),
+        }, [h('option', { value: '', selected: !s.incident.type }, '—'),
+            ...INCIDENT_TYPES.map((t) => h('option', { value: t, selected: s.incident.type === t }, t))])),
+      ),
+      h('fieldset', {},
+        h('legend', {}, 'AAR meeting'),
+        field('Date', h('input', { type: 'date', value: s.aar.date, ...bind(null, (sess, v) => { sess.aar.date = v; }) })),
+        field('Location', text(s.aar.location, (sess, v) => { sess.aar.location = v; }, { placeholder: 'e.g. Bungendore Station' })),
+        field('Facilitator', text(s.aar.facilitator, (sess, v) => { sess.aar.facilitator = v; })),
+      ),
+    ),
+    h('fieldset', {},
+      h('legend', {}, 'Attending units'),
+      h('table', { class: 'table' },
+        h('thead', {}, h('tr', {}, h('th', {}, 'Unit'), h('th', {}, 'Role'), h('th', {}, ''))),
+        unitsBody,
+      ),
+      h('button', { class: 'btn', onclick: () => store.update((sess) => sess.units.push({ unit: '', role: '' })) }, '+ Add unit'),
+    ),
+    h('fieldset', {},
+      h('legend', {}, 'Incident phases'),
+      phaseList,
+      h('button', { class: 'btn', onclick: () => store.update((sess) => sess.phases.push('')) }, '+ Add phase'),
+    ),
+    h('div', { class: 'page-actions' },
+      h('button', { class: 'btn btn--primary', onclick: () => { toast('Saved'); location.hash = '#/capture'; } }, 'Continue to Capture →'),
+    ),
+  );
+}

--- a/aar-studio/package.json
+++ b/aar-studio/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aar-studio",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "AI-facilitated After Action Reviews for fire brigades — static web app, no build step",
+  "scripts": {
+    "test": "node --test",
+    "dev": "python3 -m http.server 8080"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/aar-studio/staticwebapp.config.json
+++ b/aar-studio/staticwebapp.config.json
@@ -1,0 +1,16 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/css/*", "/js/*", "/data/*", "/*.json"]
+  },
+  "globalHeaders": {
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net blob:; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net https://*.openai.azure.com https://*.cognitiveservices.azure.com https://*.services.ai.azure.com https://*.api.cognitive.microsoft.com wss://*.stt.speech.microsoft.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; base-uri 'self'; form-action 'self'",
+    "Permissions-Policy": "microphone=(self), display-capture=(self), camera=()",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "strict-origin-when-cross-origin"
+  },
+  "mimeTypes": {
+    ".json": "application/json",
+    ".mjs": "text/javascript"
+  }
+}

--- a/aar-studio/test/audioUtils.test.js
+++ b/aar-studio/test/audioUtils.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { rms, floatToPcm16, downsampleTo16k, createSpeakerLabeler } from '../js/lib/audioUtils.js';
+
+test('rms of silence is 0 and of a full-scale square wave is 1', () => {
+  assert.equal(rms(new Float32Array(256)), 0);
+  const square = new Float32Array(256).map((_, i) => (i % 2 ? 1 : -1));
+  assert.ok(Math.abs(rms(square) - 1) < 1e-6);
+  assert.equal(rms(null), 0);
+});
+
+test('floatToPcm16 clamps and scales', () => {
+  assert.equal(floatToPcm16(0), 0);
+  assert.equal(floatToPcm16(1), 32767);
+  assert.equal(floatToPcm16(-1), -32768);
+  assert.equal(floatToPcm16(2), 32767);   // clamp
+  assert.equal(floatToPcm16(-2), -32768); // clamp
+});
+
+test('downsampleTo16k produces the right length and preserves a DC signal', () => {
+  const input = new Float32Array(48000).fill(0.5); // 1 s @ 48 kHz
+  const out = downsampleTo16k(input, 48000);
+  assert.equal(out.length, 16000);
+  assert.ok(out instanceof Int16Array);
+  assert.equal(out[8000], floatToPcm16(0.5));
+});
+
+test('downsampleTo16k passes 16 kHz input through (converted to PCM16)', () => {
+  const input = Float32Array.from([0, 0.5, -0.5, 1]);
+  const out = downsampleTo16k(input, 16000);
+  assert.deepEqual([...out], [0, floatToPcm16(0.5), floatToPcm16(-0.5), 32767]);
+});
+
+test('downsampleTo16k refuses to upsample', () => {
+  assert.throws(() => downsampleTo16k(new Float32Array(10), 8000), /upsample/);
+});
+
+test('speaker labeler is stable, ordered by first appearance, and skips Unknown', () => {
+  const label = createSpeakerLabeler();
+  assert.equal(label('Guest-3'), 'Speaker 1');
+  assert.equal(label('Guest-1'), 'Speaker 2');
+  assert.equal(label('Guest-3'), 'Speaker 1'); // stable
+  assert.equal(label('Unknown'), '');
+  assert.equal(label(null), '');
+});

--- a/aar-studio/test/dedupe.test.js
+++ b/aar-studio/test/dedupe.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { similarity, isNearDuplicate, dedupeFindings } from '../js/lib/dedupe.js';
+
+const f = (category, text) => ({ category, text });
+
+test('similarity is high for restatements, low for unrelated findings', () => {
+  const a = 'The pump was set up too close, roughly 10 m from thick smoke.';
+  const b = 'Pump set up too close — about 10 m from the thick smoke.';
+  const c = 'The BACO performance was outstanding with constant comms.';
+  assert.ok(similarity(a, b) > 0.7, `expected high, got ${similarity(a, b)}`);
+  assert.ok(similarity(a, c) < 0.2, `expected low, got ${similarity(a, c)}`);
+});
+
+test('containment catches a short restatement of a longer finding', () => {
+  const long = 'Call for more tankers up front for a going structure fire off reticulated water, and run 65 mm to staging with trucks rotating through.';
+  const short = 'Call more tankers up front for structure fires off reticulated water.';
+  assert.ok(similarity(long, short) >= 0.72);
+});
+
+test('different categories are never duplicates', () => {
+  assert.equal(isNearDuplicate(f('well', 'Monitor knocked the fire down'), f('didnt', 'Monitor knocked the fire down')), false);
+});
+
+test('dedupeFindings drops repeats across and within the incoming batch', () => {
+  const existing = [f('didnt', 'Pump positioned too close to the smoke, operator masked all night.')];
+  const incoming = [
+    f('didnt', 'The pump was positioned too close to the smoke and the operator was masked all night.'), // dup of existing
+    f('well', 'BA control went straight to a Stage 2 board with a two-cylinder limit.'),                  // new
+    f('well', 'BA control: straight to Stage 2 board, two-cylinder limit per operator.'),                 // dup within batch
+  ];
+  const { added, skipped } = dedupeFindings(existing, incoming);
+  assert.equal(added.length, 1);
+  assert.equal(skipped.length, 2);
+  assert.match(added[0].text, /Stage 2/);
+});

--- a/aar-studio/test/exports.test.js
+++ b/aar-studio/test/exports.test.js
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { emptyReport, renderSnapshotHtml, renderMarkdown, sessionFilename, renderTranscriptText } from '../js/lib/exports.js';
+import { normaliseSession } from '../js/lib/model.js';
+
+const sample = normaliseSession(JSON.parse(await readFile(new URL('../data/sample-session.json', import.meta.url), 'utf8')));
+
+test('emptyReport mirrors the session phases and pre-fills the headline', () => {
+  const r = emptyReport(sample);
+  assert.equal(r.headline, sample.incident.title);
+  assert.deepEqual(r.phases.map((p) => p.name), sample.phases);
+  assert.equal(r.actions.length, 3);
+  assert.match(r.caveat, /verify/i);
+});
+
+test('snapshot HTML renders the key sections and escapes content', () => {
+  const html = renderSnapshotHtml(sample);
+  assert.match(html, /Executive Snapshot/);
+  assert.match(html, /Wamboin Structure Fire — 412 Macs Reef Road/);
+  assert.match(html, /Top three actions/);
+  assert.match(html, /What worked/);
+  assert.match(html, /Lessons/);
+  assert.match(html, /800/); // stat value
+  assert.match(html, /Who attended/);
+  // escaping: the contextBar contains no raw < from data, prove esc works:
+  const hostile = normaliseSession({ ...sample, report: { ...sample.report, headline: '<script>alert(1)</script>' } });
+  assert.ok(!renderSnapshotHtml(hostile).includes('<script>alert(1)'));
+  assert.ok(renderSnapshotHtml(hostile).includes('&lt;script&gt;'));
+});
+
+test('snapshot HTML omits empty sections gracefully', () => {
+  const bare = normaliseSession({ incident: { title: 'Bare' }, aar: {}, units: [] });
+  const html = renderSnapshotHtml(bare);
+  assert.match(html, /Bare/);
+  assert.ok(!html.includes('Top three actions'));
+  assert.ok(!html.includes('Who attended'));
+});
+
+test('markdown summary includes report sections and the findings register', () => {
+  const md = renderMarkdown(sample);
+  assert.match(md, /^# After Action Review — Wamboin/m);
+  assert.match(md, /## Incident snapshot/);
+  assert.match(md, /## Suppression/);
+  assert.match(md, /## Consolidated recommendations/);
+  assert.match(md, /## Top three actions/);
+  assert.match(md, /## Findings register/);
+  assert.match(md, /\[Went well\]/);
+});
+
+test('transcript text applies the speaker rename map', () => {
+  const text = renderTranscriptText(sample);
+  assert.match(text, /BACO:/);          // Speaker 4 renamed
+  assert.ok(!text.includes('Speaker 4'));
+});
+
+test('sessionFilename slugifies', () => {
+  assert.equal(sessionFilename(sample, 'snapshot', 'html'), 'wamboin-structure-fire-412-macs-reef-road-snapshot.html');
+});

--- a/aar-studio/test/extraction.test.js
+++ b/aar-studio/test/extraction.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldAutoExtract, chunkSegments, findingsSchema, buildMessages, toFinding, extractFromSegments } from '../js/lib/extraction.js';
+import { extractJsonObject, chatJson, LlmError } from '../js/lib/llm.js';
+import { createSession, createSegment, GENERAL_PHASE } from '../js/lib/model.js';
+
+test('auto-extract trigger needs both elapsed time and pending words', () => {
+  assert.equal(shouldAutoExtract({ msSinceLast: 50_000, wordsPending: 100 }), true);
+  assert.equal(shouldAutoExtract({ msSinceLast: 10_000, wordsPending: 500 }), false);
+  assert.equal(shouldAutoExtract({ msSinceLast: 90_000, wordsPending: 20 }), false);
+});
+
+test('chunkSegments respects the word budget and phase boundaries', () => {
+  const seg = (phase, words) => createSegment({ phase, text: Array(words).fill('word').join(' ') });
+  const chunks = chunkSegments([seg('Arrival', 200), seg('Arrival', 200), seg('Arrival', 200), seg('Suppression', 10)], 450);
+  assert.equal(chunks.length, 3, 'split on budget then on phase change');
+  assert.equal(chunks[2][0].phase, 'Suppression');
+});
+
+test('extraction prompt carries ids, phases and terminology guidance', () => {
+  const session = createSession();
+  session.incident.title = 'Wamboin Shed Fire';
+  const segs = [createSegment({ text: 'Monitor at 800 litres a minute.', phase: 'Suppression', speaker: 'Dave' })];
+  const [system, user] = buildMessages({ session, segments: segs });
+  assert.match(system.content, /BACO/);
+  assert.match(system.content, /\(unclear\)/);
+  assert.match(system.content, /Wamboin Shed Fire/);
+  assert.ok(user.content.includes(`[${segs[0].id}]`));
+  const schema = findingsSchema(['Arrival', GENERAL_PHASE]);
+  assert.deepEqual(schema.properties.findings.items.properties.phase.enum, ['Arrival', GENERAL_PHASE]);
+});
+
+test('toFinding clamps invalid category/phase and filters unknown segment ids', () => {
+  const session = createSession();
+  const pool = [createSegment({ text: 'x' })];
+  const f = toFinding({ category: 'nonsense', phase: 'Mopup', text: ' t ', quote: 'q', segmentIds: [pool[0].id, 'bogus'] }, session, pool);
+  assert.equal(f.category, 'happened');
+  assert.equal(f.phase, GENERAL_PHASE);
+  assert.deepEqual(f.segmentIds, [pool[0].id]);
+  assert.equal(f.source, 'ai');
+});
+
+test('extractJsonObject tolerates fences and surrounding prose', () => {
+  assert.deepEqual(extractJsonObject('Sure!\n```json\n{"a": 1}\n```'), { a: 1 });
+  assert.deepEqual(extractJsonObject('prefix {"b": 2} suffix'), { b: 2 });
+  assert.throws(() => extractJsonObject('no json here'), LlmError);
+});
+
+const SETTINGS = { llmEndpoint: 'https://example.openai.azure.com', llmKey: 'k', llmDeployment: 'gpt-test', apiVersion: '2024-10-21' };
+const okResponse = (content) => ({ ok: true, json: async () => ({ choices: [{ message: { content } }] }) });
+
+test('chatJson falls back from json_schema to json_object on 400', async () => {
+  const formats = [];
+  const fetchImpl = async (url, { body }) => {
+    const format = JSON.parse(body).response_format?.type ?? 'none';
+    formats.push(format);
+    if (format === 'json_schema') return { ok: false, status: 400, json: async () => ({ error: { message: 'response_format not supported' } }) };
+    return okResponse('{"findings": []}');
+  };
+  const result = await chatJson({ settings: SETTINGS, deployment: 'gpt-test', messages: [], schema: { type: 'object' }, fetchImpl });
+  assert.deepEqual(result, { findings: [] });
+  assert.deepEqual(formats, ['json_schema', 'json_object']);
+});
+
+test('chatJson surfaces auth errors with a hint instead of retrying', async () => {
+  let calls = 0;
+  const fetchImpl = async () => { calls++; return { ok: false, status: 401, json: async () => ({ error: { message: 'bad key' } }) }; };
+  await assert.rejects(
+    chatJson({ settings: SETTINGS, deployment: 'gpt-test', messages: [], schema: { type: 'object' }, fetchImpl }),
+    (err) => err instanceof LlmError && err.status === 401 && /api-key/i.test(err.hint),
+  );
+  assert.equal(calls, 1);
+});
+
+test('extractFromSegments maps model output into session findings', async () => {
+  const session = createSession();
+  const segs = [createSegment({ text: 'The pump was ten metres from the smoke all night.', phase: 'Arrival' })];
+  const fetchImpl = async () => okResponse(JSON.stringify({
+    findings: [{ category: 'didnt', phase: 'Arrival', text: 'Pump positioned too close to the smoke.', quote: 'ten metres from the smoke', segmentIds: [segs[0].id] }],
+  }));
+  const found = await extractFromSegments({ session, segments: segs, settings: SETTINGS, fetchImpl });
+  assert.equal(found.length, 1);
+  assert.equal(found[0].category, 'didnt');
+  assert.equal(found[0].source, 'ai');
+});

--- a/aar-studio/test/reportGen.test.js
+++ b/aar-studio/test/reportGen.test.js
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { reportSchema, buildReportMessages, normaliseReport, generateReport } from '../js/lib/reportGen.js';
+import { renderCombinedHtml } from '../js/lib/exports.js';
+import { normaliseSession, createSession, GENERAL_PHASE, sessionPhases } from '../js/lib/model.js';
+
+const sample = normaliseSession(JSON.parse(await readFile(new URL('../data/sample-session.json', import.meta.url), 'utf8')));
+
+test('report schema constrains phases to the session phases', () => {
+  const schema = reportSchema(['Arrival', GENERAL_PHASE]);
+  assert.deepEqual(schema.properties.phases.items.properties.name.enum, ['Arrival', GENERAL_PHASE]);
+  assert.equal(schema.additionalProperties, false);
+});
+
+test('report prompt carries findings, units and style rules', () => {
+  const [system, user] = buildReportMessages(sample);
+  assert.match(system.content, /Bold lead/);
+  assert.match(system.content, /BACO/);
+  assert.match(user.content, /Wamboin/);
+  assert.match(user.content, /\[Arrival \| What didn't go well\]/);
+  assert.match(user.content, /Fire & Rescue NSW/);
+});
+
+test('normaliseReport keeps session phase order, clamps themes/actions, pads actions to 3', () => {
+  const session = createSession({ phases: ['Arrival', 'Suppression'] });
+  const raw = {
+    headline: ' H ',
+    stats: [{ value: '8', label: 'Appliances' }, { value: '', label: '' }],
+    phases: [
+      { name: 'Suppression', happened: 'late entry first', well: ['a'], didnt: [] },
+      { name: 'Arrival', happened: 'early', well: [], didnt: ['b'] },
+      { name: GENERAL_PHASE, happened: '', well: ['cross-cutting'], didnt: [] },
+      { name: 'Bogus', happened: 'dropped', well: [], didnt: [] },
+    ],
+    themes: [{ title: '1' , body: '' }, { title: '2', body: '' }, { title: '3', body: '' }, { title: '4', body: '' }],
+    recommendations: ['r1', ''],
+    actions: ['only one'],
+    assessment: 'ok',
+  };
+  const r = normaliseReport(raw, session);
+  assert.equal(r.headline, 'H');
+  assert.deepEqual(r.phases.map((p) => p.name), ['Arrival', 'Suppression', GENERAL_PHASE]);
+  assert.equal(r.phases[0].happened, 'early');
+  assert.equal(r.stats.length, 1);
+  assert.equal(r.themes.length, 3);
+  assert.deepEqual(r.actions, ['only one', '', '']);
+  assert.match(r.caveat, /verify/i); // default caveat filled in
+});
+
+test('generateReport maps a model reply onto the report shape', async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content: JSON.stringify({
+        headline: 'Wamboin Shed Fire', contextBar: 'No mains water',
+        stats: [{ value: '0', label: 'Injuries' }],
+        snapshot: ['It burned.'],
+        phases: sessionPhases(sample).map((name) => ({ name, happened: '', well: [], didnt: [] })),
+        themes: [], recommendations: ['Do the thing'],
+        actions: ['One', 'Two', 'Three'], assessment: 'Handled well.', caveat: 'Verify before distribution.',
+      }) } }],
+    }),
+  });
+  const settings = { llmEndpoint: 'https://x.openai.azure.com', llmKey: 'k', llmDeployment: 'mini', reportDeployment: 'big' };
+  const report = await generateReport({ session: sample, settings, fetchImpl });
+  assert.equal(report.headline, 'Wamboin Shed Fire');
+  assert.deepEqual(report.actions, ['One', 'Two', 'Three']);
+});
+
+test('generateReport refuses to run without findings', async () => {
+  await assert.rejects(
+    generateReport({ session: createSession(), settings: {}, fetchImpl: async () => {} }),
+    /No findings/,
+  );
+});
+
+test('combined report contains snapshot, summary, register and optional transcript', () => {
+  const withT = renderCombinedHtml(sample, { includeTranscript: true });
+  assert.match(withT, /Executive Snapshot/);
+  assert.match(withT, /Full summary/);
+  assert.match(withT, /Findings register/);
+  assert.match(withT, /Appendix — transcript/);
+  assert.match(withT, /BACO:/); // speaker rename map applied in the appendix
+
+  const without = renderCombinedHtml(sample);
+  assert.ok(!without.includes('Appendix — transcript'));
+  assert.match(without, /Findings register/);
+});

--- a/aar-studio/test/transcriptParser.test.js
+++ b/aar-studio/test/transcriptParser.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTranscript } from '../js/lib/transcriptParser.js';
+import { parseClock, fmtClock } from '../js/lib/text.js';
+
+test('parses the Teams DOCX copy format (Name + timestamp header, text lines)', () => {
+  const raw = [
+    'Dave Smith   0:15',
+    'Page went out cleanly, we had two and six on the initial response.',
+    '',
+    'Jane Doe   1:02',
+    'Coming up the driveway it narrows',
+    'and the ground falls away on the Delta side.',
+    '',
+  ].join('\n');
+  const { format, rows } = parseTranscript(raw);
+  assert.equal(format, 'teams-docx');
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows[0], { speaker: 'Dave Smith', t: 15, text: 'Page went out cleanly, we had two and six on the initial response.' });
+  assert.equal(rows[1].t, 62);
+  assert.match(rows[1].text, /narrows and the ground falls away/);
+});
+
+test('parses h:mm:ss Teams timestamps', () => {
+  const { rows } = parseTranscript('Dave   1:02:03\nLong meeting.\n\nJane   1:05:00\nStill going.\n');
+  assert.equal(rows[0].t, 3723);
+  assert.equal(rows[1].t, 3900);
+});
+
+test('parses "Name: text" transcripts with continuation lines', () => {
+  const raw = 'Dave: The monitor was the right call.\nJane: Agreed, single 38s did nothing\non a fire that size.';
+  const { format, rows } = parseTranscript(raw);
+  assert.equal(format, 'speaker-colon');
+  assert.equal(rows.length, 2);
+  assert.equal(rows[1].speaker, 'Jane');
+  assert.match(rows[1].text, /did nothing on a fire that size/);
+});
+
+test('does not treat prose containing a colon as a speaker header', () => {
+  const raw = 'Dave: First point.\nThe lesson for everyone here is this: set up further back from the smoke.';
+  const { rows } = parseTranscript(raw);
+  assert.equal(rows.length, 1, 'long pre-colon text should be a continuation, not a speaker');
+  assert.match(rows[0].text, /set up further back/);
+});
+
+test('parses WEBVTT with voice spans', () => {
+  const raw = [
+    'WEBVTT',
+    '',
+    '00:00:05.000 --> 00:00:09.000',
+    '<v Dave Smith>The pump was too close to the smoke.</v>',
+    '',
+    '00:00:10.500 --> 00:00:12.000',
+    'Unattributed cue text.',
+    '',
+  ].join('\n');
+  const { format, rows } = parseTranscript(raw);
+  assert.equal(format, 'vtt');
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows[0], { speaker: 'Dave Smith', t: 5, text: 'The pump was too close to the smoke.' });
+  assert.equal(rows[1].speaker, '');
+  assert.equal(rows[1].t, 10);
+});
+
+test('falls back to plain paragraphs', () => {
+  const { format, rows } = parseTranscript('First paragraph about the fire.\n\nSecond paragraph\nwrapped across lines.');
+  assert.equal(format, 'plain');
+  assert.equal(rows.length, 2);
+  assert.equal(rows[1].text, 'Second paragraph wrapped across lines.');
+});
+
+test('clock helpers round-trip', () => {
+  assert.equal(parseClock('2:05'), 125);
+  assert.equal(parseClock('00:01:05.250'), 65);
+  assert.equal(parseClock('garbage'), null);
+  assert.equal(fmtClock(125), '2:05');
+  assert.equal(fmtClock(3723), '1:02:03');
+  assert.equal(fmtClock(null), '');
+});

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -54,6 +54,18 @@ Only the following types of documents are allowed in the root `/docs/` directory
 - **Feature Guides**: `docs/FEATURE_DEVELOPMENT_GUIDE.md`, `docs/GETTING_STARTED.md`
 - **UI Review**: `docs/current_state/UI_REVIEW_20260207.md` - Comprehensive UI/UX review with iPad screenshots
 
+### Companion app: AAR Studio (June 2026)
+
+`aar-studio/` hosts **AAR Studio**, a self-contained static web app (no build
+step, no backend) for AI-facilitated After Action Reviews — live transcript
+capture, finding extraction onto a presentable board, and packaged
+snapshot/summary reports. It shares no code or deployment with Station Manager
+and deploys separately to Azure Static Web Apps via
+`.github/workflows/aar-studio.yml` (the main CI/CD pipeline ignores
+`aar-studio/**`). Its plan and architecture live in `aar-studio/docs/PLAN.md`
+and `aar-studio/docs/ARCHITECTURE.md`; the registries and AS_BUILT in this
+directory intentionally do not cover it.
+
 ---
 
 ## 🚀 MVP LAUNCH STATUS (February 2026) - v1.0


### PR DESCRIPTION
# AAR Studio

New self-contained static web app in `aar-studio/` — plain HTML/CSS/ES modules, **no build step, no backend** — that facilitates, live-presents and packages After Action Reviews for fire brigade incidents. Deploys to Azure Static Web Apps; Azure OpenAI / Azure AI Speech are called directly from the browser with keys held in `localStorage` only.

Plans and docs: `aar-studio/docs/PLAN.md` (staged roadmap), `aar-studio/docs/ARCHITECTURE.md`, `aar-studio/README.md` (local dev, Azure resource setup, key handling, deployment).

## Delivered in this PR (Stages 1–4)

- **Session setup** — incident title/date/location/type, AAR date/location, facilitator, attending units (unit + role), configurable phases (default Arrival → Rescue → Suppression → Overhaul, plus an implicit General bucket).
- **Persistence** — one `localStorage` key per session, autosave on every mutation, session list / open / delete, JSON import & export.
- **Live listen (real-time capture)** — room microphone (primary mode: one mic, many speakers), shared Teams tab/system audio via `getDisplayMedia`, or an uploaded audio file; one shared pipeline (AudioWorklet tap → 16 kHz mono PCM16 → Azure Speech push stream) with an RMS level meter from the same tap. Azure AI Speech SDK lazy-loaded from jsDelivr; `ConversationTranscriber` with diarization toggle (en-AU default), interim results on screen, diarised ids mapped to stable renameable "Speaker N" labels, optional local MediaRecorder backup recording offered as a download. Findings keep flowing onto the board as the discussion progresses: auto-extraction every ~45 s / 70 words, on phase change, on demand, and a final pass on stop.
- **Transcript ingest (offline path)** — paste parser for the Teams DOCX copy format (`Name   m:ss` header + text lines), `Name: text` lines, and WEBVTT (incl. `<v Speaker>` tags), with plain-paragraph fallback.
- **AI findings extraction** — Azure OpenAI chat completions (Foundry deployments): structured outputs (`json_schema` strict) with graceful fallback to `json_object` → plain-JSON parsing; no `temperature`/`max_tokens` (reasoning-model compatible); actionable CORS/auth/deployment error hints; chunked prompts with the AAR-specific rules (single-mic garble correction, "(unclear)" marking, Australian fire-service terminology, verbatim quote + source segment ids per finding); near-duplicate dedupe.
- **Live board** — four category columns with counts, phase chips + filter, manual quick-add, edit/delete, fullscreen high-contrast **Present mode** for the projector.
- **Review** — edit/recategorise/rephase/delete findings, edit segment text/phase/speaker, rename diarised speakers (map applied everywhere).
- **Report studio** — **AI report generation from the curated findings** (strict schema aligned to the session's phases, snapshot-artwork style rules, optional separate report deployment with fallback, regenerate-with-confirm), every field editable with live preview; exports: one-page executive snapshot HTML (matching the Wamboin one-pager structure), **combined HTML report** (snapshot + full summary + findings register + optional transcript appendix, print-paginated), Markdown summary + findings register, session JSON, print-to-PDF.
- **Settings dialog** — Azure OpenAI endpoint/deployments/api-version/key + Speech key/region/language/diarization, with a **Test connection** button.
- **Sample data** — `data/sample-session.json` built from the Wamboin structure fire AAR so Board/Review/Report are demoable with zero Azure setup (Home → *Load Wamboin sample*).
- **Ops** — `staticwebapp.config.json` (CSP limited to self + jsDelivr + Azure OpenAI/Speech domains; `Permissions-Policy` for mic/display-capture), new `.github/workflows/aar-studio.yml` (node tests + SWA deploy from `main`, needs the `AZURE_STATIC_WEB_APPS_API_TOKEN_AAR_STUDIO` secret), zero-dependency `node --test` suite (**37 tests, all passing**) covering parser, dedupe, exports, extraction policy, the LLM fallback chain, report generation, and the audio utils.

## Not in this PR (Stage 5 polish, specified in PLAN.md)

- Dedupe threshold tuning with real transcripts and a merge-suggestion UI; deeper accessibility pass; per-unit finding attribution; optional `?demo` deep link.

## Station Manager impact

Minimal and isolated: `aar-studio/**` added to the main pipeline's push `paths-ignore`, and a short MASTER_PLAN.md section points at the app's own plan. No backend/frontend code touched.

## Verification

- `cd aar-studio && npm test` — 37/37 passing on Node 22.
- All modules pass `node --check`; app serves and all relative imports resolve via `python3 -m http.server`; Speech SDK pinned version + bundle path verified against the npm package.
- No headless browser or microphone in this environment, so the live paths need a real click-through: serve `aar-studio/` over `localhost`/HTTPS, set Speech + OpenAI keys in ⚙ Settings, start *Room microphone*, talk, watch segments + findings appear, then hit Report → *Generate with AI* and check the exports.

https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S