### PR TITLE
fix(pwa): exclude /aar from service-worker navigateFallback (AAR Studio blank screen)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -80,6 +80,12 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
         // Ensure dev builds with minimal assets don't warn by allowing the generated SW bundle
         globIgnores: ['**/node_modules/**/*'],
+        // Don't serve the React app shell (navigateFallback) for the AAR Studio
+        // sub-app or the API. The SW is scoped to '/', so without this denylist it
+        // intercepts /aar navigations and returns the main index.html, leaving a
+        // blank screen instead of letting the request reach the server (which
+        // serves the standalone AAR Studio bundle).
+        navigateFallbackDenylist: [/^\/aar/, /^\/api/],
         // Network-first strategy for API calls
         runtimeCaching: [
           {


### PR DESCRIPTION
## Problem

Navigating to **`/aar`** showed a blank white screen. The browser console showed Workbox internals, Microsoft Clarity, Google-Fonts fetches, and the **main app's** CSP — i.e. the React app shell was being served at `/aar`, not the AAR Studio bundle.

## Root cause

The main app's PWA service worker (generated by `vite-plugin-pwa`, scope `/`) serves the React `index.html` via `navigateFallback` for **all** navigations, and had **no `navigateFallbackDenylist`**. So the SW intercepted the `/aar` navigation and returned the main app's HTML instead of letting it reach the server (which serves the standalone AAR Studio bundle). React Router has no `/aar` route → blank screen.

The server side was already correct — the SPA fallback in `backend/src/index.ts` excludes `/aar`, and a direct, SW-bypassing request to `/aar` returns AAR Studio. This was purely the client-side service worker.

## Fix

One line in `frontend/vite.config.ts` `workbox`:

```js
navigateFallbackDenylist: [/^\/aar/, /^\/api/],
```

`/aar` navigations now bypass the SPA fallback and load AAR Studio from the server; `/api` is excluded for good measure. `autoUpdate` + `skipWaiting` + `clientsClaim` means existing clients pick up the corrected SW on next load.

## Test plan

- [x] `tsc -b --noEmit` (frontend) passes
- [ ] After deploy: navigating to `/aar` loads AAR Studio (not a blank screen)
- [ ] Main app routes (`/`, `/signin`, deep links) still work offline via the SPA fallback
- [ ] Pre-deploy confirmation: `/aar` already loads correctly in an Incognito window or after unregistering the existing service worker

## Notes

- Created from a fresh branch off `main` (the previous working branch was fully squash-merged).
- Frontend-only change; triggers the full CI pipeline (deploy gated to `main`).

https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S)_