### PR TITLE
docs+fix: integration-seam conventions in CLAUDE.md + gstatic CSP connect-src

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,26 @@ RFS Station Manager — a real-time digital sign-in system for NSW Rural Fire
 Service stations. Members check in/out, track activities, run truck checks, and
 view reports. Changes sync live across kiosks/tablets/phones via WebSockets.
 
-- **Monorepo**: `backend/` (Express 5 + Socket.io + TypeScript) and
-  `frontend/` (React 19 + Vite 7 + TypeScript). Root `package.json` orchestrates both.
-- **Status**: v1.0 MVP in production (sign-in only). Truck Check + Reports built
-  but gated behind "Coming in v1.1" on the landing page.
+- **Monorepo — three apps, one deployment**:
+  - `backend/` (Express 5 + Socket.io + TypeScript) — the API + Socket.io server;
+    also serves the two frontends in prod.
+  - `frontend/` (React 19 + Vite 7 + TypeScript) — the main SPA at `/`.
+  - `aar-studio/` — a **no-build vanilla HTML/CSS/ES-module** sub-app served at
+    `/aar` (AI-facilitated After Action Reviews; its own `node --test` suite, its
+    own docs under `aar-studio/docs/`). Shares no code with the SPA.
+
+  Root `package.json` orchestrates backend + frontend. See "Multi-app structure
+  & integration seams" below — most recent production bugs came from the seams
+  between these apps (service worker, CSP, CORS).
+- **Status**: v1.1 in production — sign-in, truck check, and reports all shipped.
+  Features are gated per-organization by SaaS **entitlements** (see "SaaS tenancy
+  & entitlements"). AAR Studio is live at `/aar`. Stripe billing is designed
+  (`docs/SAAS_COMMERCIALIZATION_DESIGN.md`) but **not yet wired**.
 - **DB**: Azure Table Storage in prod; in-memory store for local dev/tests.
   Selected at runtime by `dbFactory` (see below).
-- **Deploy**: GitHub Actions → Azure App Service (`bungrfsstation`). Frontend
-  `dist/` is served by the backend in prod.
+- **Deploy**: GitHub Actions → Azure **Linux** App Service (`bungrfs-linux`). The
+  backend serves `frontend/dist` (at `/`) and the `aar-studio/` bundle (at
+  `/aar`); `ci-cd.yml` packages all three into one deploy zip.
 
 ## Commands
 
@@ -45,9 +57,11 @@ npx tsc -b --noEmit    # typecheck (CI gate)
 ```
 
 **CI gates (`.github/workflows/ci-cd.yml`)**, in order: backend typecheck →
-backend tests → frontend lint → frontend typecheck → frontend tests → build.
-All must pass. Deploy runs only on `main`. Docs-only changes (`docs/**`, `*.md`)
-skip the pipeline.
+backend tests → frontend lint → frontend typecheck → frontend tests → AAR Studio
+tests (`node --test`) → build. All must pass. Deploy runs only on `main` (the zip
+bundles `backend/dist` + `frontend/dist` + `aar-studio/`). Docs-only changes
+(`docs/**`, `*.md`) skip the pipeline. There is no separate AAR Studio workflow —
+it was folded into this pipeline.
 
 ## Architecture (how data flows)
 
@@ -67,30 +81,96 @@ Socket events: `checkin`, `activity-change`, `member-added`, `event-created`,
 - Selection priority: Table Storage if `USE_TABLE_STORAGE=true` (or dev +
   `AZURE_STORAGE_CONNECTION_STRING` present), else in-memory.
 
+## Multi-app structure & integration seams
+
+The main SPA (`/`) and AAR Studio (`/aar`) share **one origin**, so browser- and
+deploy-level concerns must be handled consistently. These are the seams — when
+you touch any of them, check **all** of the listed places, because each recent
+prod outage came from updating one and forgetting the others:
+
+- **Service worker (PWA)** — `frontend/vite.config.ts` (`VitePWA`/`workbox`). The
+  SW is scoped to `/` and uses `navigateFallback` to the SPA shell. It **must**
+  keep `navigateFallbackDenylist: [/^\/aar/, /^\/api/]` or it serves the React
+  shell for `/aar` (blank screen) and `/api`.
+- **SPA fallback (server)** — `backend/src/index.ts` regex
+  `/^\/(?!api|assets|aar).*/`. Mirrors the SW denylist; any new sub-app path must
+  be excluded here too.
+- **CSP** — set in **two** places in `index.ts`: Helmet's global policy (main
+  app) and a **scoped override middleware on `/aar`** (looser: jsDelivr scripts,
+  Azure OpenAI/Speech `connect-src`, mic/display-capture). Note `connect-src`
+  also governs **`fetch()` made by the service worker** (e.g. Google-Fonts
+  caching) — a host can be in `font-src` and still be blocked if it's missing
+  from `connect-src`. Keep AAR-only hosts in the `/aar` override, not the global
+  policy.
+- **CORS** — single `allowedOriginsList` from `FRONTEND_URLS` (`index.ts`), reused
+  by Express **and** Socket.io. The origin callback must **deny without throwing**
+  (`callback(null, false)`); throwing 500s every same-origin asset request.
+  `FRONTEND_URLS` must include the prod origin (the Bicep/App-Service setting),
+  or it falls back to `localhost` and blocks everything.
+- **Static mounts & deploy packaging** — `index.ts` mounts `frontend/dist` at `/`
+  and `aar-studio/` at `/aar` (guarded by `fs.existsSync`, path via
+  `AAR_STUDIO_PATH`). `ci-cd.yml`'s "Create deployment package" step must copy
+  `aar-studio/` into the zip.
+
+**Adding a new sub-app or external resource:** update the SW denylist, the SPA
+fallback regex, the relevant CSP directive(s) (scoped, not global), the deploy
+package step, and the static mount — together.
+
+## SaaS tenancy & entitlements
+
+Organizations are the billing tenant; features are gated per-org. Default-**off**
+(`ENABLE_ENTITLEMENTS` env) for single-tenant/kiosk back-compat.
+
+- **Model** (`backend/src/types/index.ts`, `backend/src/constants/plans.ts`):
+  `Organization` (`planCode` `community|basic|ai`, `status`, `entitlements`,
+  reserved `stripeCustomerId`/`stripeSubscriptionId`). `Entitlements` =
+  `signInEnabled | truckCheckEnabled | reportsEnabled | aiEnabled` + limits
+  (`maxStations`, `maxDevices`, `aiIncludedSessions`). `plans.ts` maps plan →
+  default entitlements and clamps owner overrides to the plan ceiling.
+- **Backend gating** — `requireFeature('<feature>')` middleware
+  (`middleware/entitlements.ts`) on the matching `/api/*` mount in `index.ts`.
+  No-op when entitlements are disabled or there's no org context (kiosk/demo).
+- **Frontend gating** — `<FeatureRoute feature="...">` wraps entitlement-gated
+  routes; `<ProtectedRoute>` wraps **auth**-gated (admin) routes. `AuthContext`'s
+  `hasFeature()` reads the org's entitlements from `/api/auth/me`.
+- **Rule:** a gated feature must be wrapped on **both** sides (FeatureRoute +
+  requireFeature) and its flag added to `Entitlements` + `plans.ts`. Use
+  `FeatureRoute` for plan features, `ProtectedRoute`/`requireOwner`/`requireAdmin`
+  for admin/role — never mix the two.
+- **Not yet built:** Stripe checkout/portal/webhooks, usage metering
+  (`UsageRecord`), and gating on a few routes (`export`, station/device limits).
+  See `docs/SAAS_COMMERCIALIZATION_DESIGN.md` and `docs/CONSOLIDATION_REVIEW.md`.
+
 ## Backend file index (`backend/src/`)
 
 - `index.ts` — Express app bootstrap: env load, helmet/CORS/compression,
   rate limiters, route registration, Socket.io server, DB + demo-station seeding.
 - **routes/** (REST handlers, mounted under `/api/*`): `members.ts`,
   `activities.ts`, `checkins.ts`, `events.ts`, `stations.ts`, `truckChecks.ts`,
-  `reports.ts`, `brigadeAccess.ts`, `export.ts`, `auth.ts`, `achievements.ts`.
+  `reports.ts`, `brigadeAccess.ts`, `export.ts`, `auth.ts` (signup/login/me),
+  `organizations.ts` (SaaS tenant + plan management), `achievements.ts`.
 - **services/** (business logic + persistence):
-  - In-memory: `database.ts`, `truckChecksDatabase.ts`, `adminUserDatabase.ts`.
+  - In-memory: `database.ts`, `truckChecksDatabase.ts`, `adminUserDatabase.ts`,
+    `organizationDatabase.ts`.
   - Table Storage: `tableStorageDatabase.ts`, `tableStorageTruckChecksDatabase.ts`,
-    `tableStorageAdminUserDatabase.ts`, `azureStorage.ts` (blob).
+    `tableStorageAdminUserDatabase.ts`, `tableStorageOrganizationDatabase.ts`,
+    `azureStorage.ts` (blob).
   - Factories: `dbFactory.ts`, `dbFactoryHelper.ts`, `truckChecksDbFactory.ts`,
-    `adminUserDbFactory.ts`.
+    `adminUserDbFactory.ts`, `organizationDbFactory.ts`.
   - Other: `brigadeAccessService.ts`, `achievementService.ts`,
     `csvExportService.ts`, `rolloverService.ts` (midnight rollover),
     `rfsFacilitiesParser.ts` (station CSV lookup), `demoStationSeeder.ts`,
     `defaultMembers.ts`, `logger.ts` (winston), `appInsights.ts`,
     `errorHandler.ts`, `version.ts`.
-- **middleware/**: `auth.ts` + `flexibleAuth.ts` (JWT/admin), `rateLimiter.ts`,
+- **middleware/**: `auth.ts` + `flexibleAuth.ts` (JWT/admin/brigade-token),
+  `entitlements.ts` (`requireFeature`, `attachOrganization`), `rateLimiter.ts`,
   `kioskModeMiddleware.ts`, `stationMiddleware.ts`, `requestId.ts`,
   `requestLogging.ts`, `validationHandler.ts`, and per-resource `*Validation.ts`
   (express-validator chains).
-- **types/**: `index.ts` (core domain types), `achievements.ts`, `stations.ts`.
-- **constants/stations.ts**, **utils/auditUtils.ts**.
+- **types/**: `index.ts` (core domain types incl. `Organization`/`Entitlements`),
+  `achievements.ts`, `stations.ts`.
+- **constants/stations.ts**, **constants/plans.ts** (plan → entitlements),
+  **utils/auditUtils.ts**.
 - **scripts/**: one-off ops (seed/purge/upload). See `scripts/README.md`.
 - **__tests__/**: Jest integration tests, one per route/service. **__mocks__/**:
   Azure SDK + uuid mocks for tests.
@@ -100,13 +180,18 @@ Socket events: `checkin`, `activity-change`, `member-added`, `event-created`,
 - `App.tsx` — Router. All routes lazy-loaded via `React.lazy` + `<Suspense>`.
 - `main.tsx`, `index.css` (CSS vars / RFS theme), `animations.css`.
 - **features/** (route-level, self-contained):
-  - `landing/` (`/`), `signin/` (`/signin`, `/signin/:linkId`),
-    `profile/` (`/profile/:memberId`), `auth/` (`/login`).
+  - `landing/` (`/` — public app picker), `signin/` (`/signin` gated,
+    `/sign-in` ungated external-link entry), `profile/` (`/profile/:memberId`),
+    `auth/` (`/login`, `/signup`).
   - `admin/stations/` (`/admin/stations`), `admin/brigade-access/`
-    (`/admin/brigade-access`).
+    (`/admin/brigade-access`), `admin/organization/` (`/admin/organization` —
+    plan/users) — all auth-gated.
   - `reports/` (`/reports*` — gated), `truckcheck/` (`/truckcheck*` — gated).
+  - AAR Studio is **not** here — it's the separate `aar-studio/` bundle, linked
+    from the landing page as a plain `<a href="/aar/">`.
 - **components/** — shared UI (Header, Toast, MemberList, ActivitySelector,
-  EventCard, DataTable, charts: `HeatMapChart`/`KPICard`/`InsightCard`, PWA bits:
+  EventCard, DataTable, `FeatureRoute` (entitlement gate), `ProtectedRoute`
+  (auth gate), charts: `HeatMapChart`/`KPICard`/`InsightCard`, PWA bits:
   `InstallPrompt`/`OfflineIndicator`, etc.). Most have a colocated `.css` and
   many a `.test.tsx`.
 - **contexts/**: `AuthContext`, `StationContext`, `ToastContext`.
@@ -129,6 +214,10 @@ Socket events: `checkin`, `activity-change`, `member-added`, `event-created`,
 - `docs/API_DOCUMENTATION.md`, `docs/openapi.yaml` — REST/WS reference.
 - `docs/GETTING_STARTED.md`, `docs/FEATURE_DEVELOPMENT_GUIDE.md` — dev guides.
 - `docs/AZURE_DEPLOYMENT.md`, `docs/ci_pipeline.md` — deploy/CI.
+- `docs/CONSOLIDATION_REVIEW.md` — cross-app coherence roadmap (design-system
+  unification, server-side AI gateway, AAR identity/persistence, shared types).
+- `docs/SAAS_COMMERCIALIZATION_DESIGN.md` — plans/pricing, Stripe billing design,
+  usage metering. `docs/AI_MAINTENANCE_AGENT_DESIGN.md` — server-side AI agent.
 - `.github/copilot-instructions.md` — full conventions (this file is the short form).
 - `docs/archive/` historical; `docs/implementation-notes/` deep dives;
   `docs/current_state/` dated snapshots + UI screenshots.
@@ -140,8 +229,12 @@ Socket events: `checkin`, `activity-change`, `member-added`, `event-created`,
   must be lazy-loaded and wrapped in `<Suspense fallback={<LoadingFallback />}>`.
 - **CSS**: component-scoped files, BEM-ish names, use vars from `index.css`.
   No inline styles.
-- **NSW RFS brand**: red `#e5281B`, lime `#cbdb2a`. Touch targets ≥ 60px
-  (kiosk). WCAG 2.1 AA. UI changes need iPad portrait+landscape screenshots in the PR.
+- **NSW RFS brand**: red `#e5281B`, lime `#cbdb2a`, Public Sans. Touch targets
+  ≥ 60px (kiosk). WCAG 2.1 AA. UI changes need iPad portrait+landscape
+  screenshots in the PR. (AAR Studio currently uses its own divergent palette —
+  unifying these is `CONSOLIDATION_REVIEW.md` #2.)
+- **Gating**: plan features use `FeatureRoute` + backend `requireFeature`; admin
+  uses `ProtectedRoute` + `requireOwner`/`requireAdmin`. Gate on both sides.
 - **API calls** go through `services/api.ts`; **DB access** through a factory.
 - **Tests** encouraged for new routes/services/components (coverage thresholds
   currently not enforced). Backend tests use the in-memory DB.
@@ -156,6 +249,15 @@ Socket events: `checkin`, `activity-change`, `member-added`, `event-created`,
   Storage twin, plus the shared type.
 - Demo station auth is intentionally bypassed (see `demoStationAuth` handling) —
   don't "fix" it as a vulnerability.
+- **The `/aar` seams bite** (see "Multi-app structure"): the service-worker
+  `navigateFallbackDenylist`, the SPA-fallback regex, and the scoped `/aar` CSP
+  must all stay in sync. A blank `/aar` screen = the SW served the React shell
+  (denylist regression); 500s on assets = CORS throwing or `FRONTEND_URLS` wrong;
+  blocked font/analytics fetches = host missing from `connect-src` (which governs
+  SW `fetch()`, not just `font-src`).
+- Entitlement gating is **default-off** (`ENABLE_ENTITLEMENTS`). With it off,
+  `requireFeature`/`FeatureRoute` allow everything — don't assume a feature is
+  locked just because it's wrapped.
 - Post-deployment smoke tests are disabled in CI (need ts-node, prod has no dev
   deps). Don't rely on them.
 - Node 22.x / npm ≥ 10 required.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -135,6 +135,9 @@ app.use(helmet({
         "https://www.clarity.ms", // Microsoft Clarity analytics endpoint
         "https://z.clarity.ms", // Microsoft Clarity data collection endpoint
         "https://fonts.googleapis.com", // Google Fonts CSS (Fetch API)
+        "https://fonts.gstatic.com", // Google Fonts files — the service worker fetch()es
+                                     // these to cache them; connect-src governs SW fetch,
+                                     // so font-src alone isn't enough (CSP error otherwise)
       ],
       // Allow self-hosted fonts, data URIs, and Google Fonts
       fontSrc: [


### PR DESCRIPTION
## What

A coherence/hardening pass following the AAR Studio integration bugs, so this class of issue is documented and one real latent bug is fixed.

### CLAUDE.md — describe the project as it is now
The guide had drifted (pre-AAR, pre-SaaS, old Windows App Service). Rewritten to reflect **three apps in one deployment** (backend, frontend SPA at `/`, AAR Studio at `/aar`), the `bungrfs-linux` Linux App Service, and v1.1 + SaaS entitlements. Two new sections codify how to avoid the recent bug class:

- **Multi-app structure & integration seams** — the service-worker `navigateFallbackDenylist`, the SPA-fallback regex, the scoped `/aar` CSP, CORS deny-without-throw, `FRONTEND_URLS`, static mounts, and deploy packaging, with the rule to **update them together**. Every recent prod outage came from changing one and forgetting the rest.
- **SaaS tenancy & entitlements** — `Organization`/`PlanCode`/`Entitlements`, `requireFeature` (backend) + `FeatureRoute` (frontend) + `ProtectedRoute`, the `ENABLE_ENTITLEMENTS` default-off flag, Stripe-reserved fields, and what's not yet built.

Plus refreshed file indexes (organizations, entitlements, `plans.ts`, FeatureRoute/ProtectedRoute), conventions, and gotchas.

### Backend — fix a confirmed latent CSP bug
Added `https://fonts.gstatic.com` to the **global CSP `connect-src`**. The PWA service worker `fetch()`es Google Font files to cache them, and `connect-src` governs SW `fetch` — having gstatic only in `font-src` left it blocked. This is the `Connecting to fonts.gstatic.com violates ... connect-src` console error seen alongside the `/aar` blank screen.

## Notes
- Independent of the `/aar` service-worker fix (PR #541) — different files, no overlap.
- `tsc --noEmit` (backend) passes.

## Test plan
- [x] backend typecheck passes
- [ ] After deploy: no `connect-src` CSP error for `fonts.gstatic.com` in console; fonts cache via the SW

https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S)_