### PR TITLE
feat(aar): friendly, non-technical AAR workflow (quick kick-off + automatic findings/metadata)

### DIFF
--- a/aar-studio/README.md
+++ b/aar-studio/README.md
@@ -16,32 +16,34 @@ lives in `localStorage`.
 
 ## The workflow
 
-1. **Setup** — incident title/date/location/type, AAR date/location,
-   facilitator, attending units, configurable phases (default Arrival, Rescue,
-   Suppression, Overhaul, plus an implicit General bucket).
-2. **Capture** — **live listen**: room microphone (primary mode — one mic,
-   many speakers), a shared Teams tab ("Share audio" ticked), or an uploaded
-   recording, transcribed in real time by Azure AI Speech with optional
-   diarization, interim results on screen, an input level meter, and an
-   optional local backup recording offered as a download. Or paste a Teams
-   transcript (the DOCX copy format, `Name: text` lines, or WEBVTT). Click
-   the current phase as the room moves through it — findings keep flowing
-   onto the board automatically (~every 45 s / 70 words, on phase change,
-   and on demand).
-3. **Board** — AI extracts discrete findings into four columns (*what
-   happened / went well / didn't go well / next time*) with phase chips,
-   dedupe, manual quick-add, and a fullscreen high-contrast **Present** mode
-   for the projector.
-4. **Review** — edit findings and transcript, rename diarised speakers.
-5. **Report** — AI drafts the structured report from your curated findings
-   (headline, context bar, key stats, snapshot, per-phase detail, themes,
-   recommendations, top three actions, assessment, verification caveat);
-   every field stays editable with live preview. Export a one-page snapshot
-   HTML, a combined HTML report (snapshot + full summary + findings register
-   + optional transcript appendix), Markdown summary, session JSON, or print
-   to PDF.
+The app is built for a non-technical facilitator: **just talk, and it does the
+heavy lifting.** You can fill in details if you want to, but you never have to.
 
-Load the **Wamboin sample** from the home screen to see a finished session
+1. **Start recording now** (quick kick-off) — one tap creates a review with
+   today's date/time (and the device's location if allowed), then starts the
+   room microphone immediately. No form to fill first. (Prefer to enter the
+   incident title/location/units up front? "Set up a review first" is there too,
+   but it's optional.)
+2. **Capture** — room microphone (one mic, many speakers), a shared Teams tab
+   ("Share audio" ticked), or an uploaded recording, transcribed in real time by
+   Azure AI Speech with optional diarization, interim results on screen, a level
+   meter, and an optional local backup recording. **No phase-clicking and no
+   "analyse" button** — findings appear automatically as the discussion goes on,
+   and the AI works out which incident phase each one belongs to. On stop, it
+   also fills in any blank incident details (title, location, attending crews,
+   type) from what was said.
+3. **Findings** — discrete findings land in four columns (*what happened / went
+   well / didn't go well / next time*) with phase chips, dedupe, manual
+   quick-add, and a fullscreen high-contrast **Present** mode for the projector.
+4. **Edit** — adjust findings and transcript, rename speakers — only if you want
+   to. The defaults are meant to stand on their own.
+5. **Report** — AI drafts the structured report from the findings (headline,
+   context bar, key stats, snapshot, per-phase detail, themes, recommendations,
+   top three actions, assessment, verification caveat); every field stays
+   editable with live preview. Export a one-page snapshot HTML, a combined HTML
+   report, Markdown summary, a backup file, or print to PDF.
+
+Choose **See an example** on the home screen to explore a finished review
 without any Azure setup.
 
 ## Local development

--- a/aar-studio/css/app.css
+++ b/aar-studio/css/app.css
@@ -315,3 +315,41 @@ body.present .board__empty { color: #93a1ad; }
 @media print {
   .topbar, .board-toolbar, .quick-add, .phase-filter, .toast-host { display: none; }
 }
+
+/* ---------- friendly home + capture (non-technical flow) ---------- */
+.hero--home { background: linear-gradient(135deg, var(--ink), var(--ink-2)); padding: 2rem 1.6rem; }
+.hero__hint { font-size: 0.85rem; color: #aebac4 !important; margin-top: 0.9rem; }
+.btn--hero { min-height: 64px; padding: 0.9rem 1.6rem; font-size: 1.1rem; font-weight: 700; }
+.hero .btn--hero.btn--primary { box-shadow: var(--shadow); }
+
+.reviews { margin-bottom: 1.6rem; }
+.review-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 0.9rem; }
+.review-card {
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+  box-shadow: var(--shadow); padding: 1rem; cursor: pointer;
+  display: flex; flex-direction: column; gap: 0.6rem; transition: border-color 0.15s, transform 0.05s;
+}
+.review-card:hover { border-color: var(--red); }
+.review-card:active { transform: translateY(1px); }
+.review-card__title { font-size: 1rem; margin: 0; color: var(--ink); }
+.review-card__meta { margin: 0.1rem 0 0; font-size: 0.85rem; color: var(--muted); }
+.review-card__stat { margin: 0; font-size: 0.82rem; font-weight: 600; color: var(--ink-2); }
+.review-card__actions { display: flex; gap: 0.3rem; justify-content: flex-end; }
+.icon-btn--danger:hover { color: #fff; background: var(--red); }
+
+.home-footer { display: flex; align-items: center; gap: 0.5rem; color: var(--muted); padding: 0.5rem 0 1.5rem; }
+.home-footer__sep { color: var(--line); }
+.link-btn { background: none; border: 0; color: var(--ink-2); text-decoration: underline; cursor: pointer; font-size: 0.88rem; padding: 0.4rem; min-height: 44px; }
+.link-btn:hover { color: var(--red); }
+
+.capture-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.panel--capture { display: flex; flex-direction: column; gap: 0.8rem; }
+.capture-start { display: flex; }
+.capture-start .btn--hero { width: 100%; }
+.more-ways { margin-top: 0.4rem; }
+.more-ways summary, .paste-section summary, .advanced summary { cursor: pointer; color: var(--ink-2); font-weight: 600; padding: 0.5rem 0; min-height: 44px; }
+.live__progress { margin: 0.2rem 0 0; }
+.setup-intro { max-width: 60ch; margin-top: -0.2rem; }
+.paste-section { margin-top: 1rem; }
+.paste-section .paste-box { margin-top: 0.5rem; }
+.advanced { border-top: 1px solid var(--line); padding-top: 0.6rem; margin-top: 1rem; }

--- a/aar-studio/js/analyse.js
+++ b/aar-studio/js/analyse.js
@@ -5,7 +5,7 @@
 import { toast } from './ui.js';
 import * as store from './store.js';
 import { getSettings } from './settings.js';
-import { extractFromSegments, shouldAutoExtract } from './lib/extraction.js';
+import { extractFromSegments, extractMetadata, mergeMetadata, shouldAutoExtract } from './lib/extraction.js';
 import { dedupeFindings } from './lib/dedupe.js';
 import { LlmError } from './lib/llm.js';
 
@@ -27,6 +27,39 @@ export async function maybeAutoExtract() {
   if (analysing) return;
   if (!shouldAutoExtract({ msSinceLast: Date.now() - lastExtractAt, wordsPending: pendingWords })) return;
   await analyseNow(null, { quiet: true });
+}
+
+/**
+ * Fill in blank incident details (title, location, type, units) from the
+ * discussion. Non-destructive — never overwrites anything the user typed.
+ * Quiet by default; toasts only when it actually fills something in.
+ */
+export async function fillMetadataFromDiscussion({ quiet = true } = {}) {
+  const session = store.getSession();
+  if (!session?.segments.some((seg) => seg.text.trim())) return;
+  // Nothing left to fill? Skip the call.
+  const blank = !session.incident.title?.trim() || !session.incident.location?.trim()
+    || !session.incident.type || !(session.units ?? []).length;
+  if (!blank) return;
+  try {
+    const meta = await extractMetadata({ session, segments: session.segments, settings: getSettings() });
+    const patch = mergeMetadata(session, meta);
+    if (!patch.incident && !patch.units) return;
+    store.update((s) => {
+      if (patch.incident) Object.assign(s.incident, patch.incident);
+      if (patch.units) s.units = patch.units;
+    }, { reason: 'session' });
+    const filled = [
+      patch.incident?.title && 'title',
+      patch.incident?.location && 'location',
+      patch.incident?.type && 'type',
+      patch.units && 'units',
+    ].filter(Boolean);
+    if (filled.length) toast(`Filled in the ${filled.join(', ')} from the discussion`);
+  } catch (err) {
+    // Best-effort — a metadata miss shouldn't disrupt the review.
+    if (!quiet) toast(`Couldn't read details from the discussion: ${err.message}`, 'error');
+  }
 }
 
 /**

--- a/aar-studio/js/audio/live.js
+++ b/aar-studio/js/audio/live.js
@@ -10,7 +10,7 @@ import { createSegment } from '../lib/model.js';
 import { countWords } from '../lib/text.js';
 import { rms, downsampleTo16k, createSpeakerLabeler } from '../lib/audioUtils.js';
 import { loadSpeechSdk, createTranscriber } from './speech.js';
-import { noteNewWords, maybeAutoExtract, analyseNow } from '../analyse.js';
+import { noteNewWords, maybeAutoExtract, analyseNow, fillMetadataFromDiscussion } from '../analyse.js';
 
 export const SOURCES = {
   mic: { label: 'Room microphone', icon: '🎙' },
@@ -221,9 +221,11 @@ export async function stop() {
   await teardown();
   state.status = 'idle';
   emit();
-  // Wrap up: analyse whatever the last extraction pass hasn't seen.
+  // Wrap up: analyse whatever the last extraction pass hasn't seen, then fill in
+  // any incident details the discussion revealed (title, location, units, type).
   const session = store.getSession();
   if (session?.segments.some((seg) => !seg.analysed && seg.text.trim())) {
-    analyseNow(null, { quiet: true });
+    await analyseNow(null, { quiet: true });
   }
+  fillMetadataFromDiscussion();
 }

--- a/aar-studio/js/lib/extraction.js
+++ b/aar-studio/js/lib/extraction.js
@@ -2,7 +2,7 @@
 // policy. The only impure part is the chatJson call.
 
 import { chatJson } from './llm.js';
-import { CATEGORIES, CATEGORY_IDS, GENERAL_PHASE, sessionPhases, createFinding } from './model.js';
+import { CATEGORIES, CATEGORY_IDS, GENERAL_PHASE, INCIDENT_TYPES, sessionPhases, createFinding } from './model.js';
 import { countWords, fmtClock } from './text.js';
 
 /** Live auto-extraction policy: ≥45 s elapsed AND ≥70 new words pending. */
@@ -108,6 +108,89 @@ export function toFinding(raw, session, segmentPool) {
     segmentIds: (Array.isArray(raw.segmentIds) ? raw.segmentIds : []).filter((id) => validIds.has(id)),
     source: 'ai',
   });
+}
+
+// --- Incident metadata, pulled from the discussion ---------------------------
+// The friendly flow lets people just start recording; the AI then fills in the
+// title / location / type / units from what's said, so they rarely have to type.
+
+export function metadataSchema() {
+  return {
+    type: 'object',
+    properties: {
+      title: { type: 'string', description: 'Short incident title, e.g. "Structure fire — 412 Macs Reef Road". "" if not stated.' },
+      location: { type: 'string', description: 'Where the incident was. "" if not stated.' },
+      incidentType: { type: 'string', enum: ['', ...INCIDENT_TYPES], description: 'Closest matching type, or "" if unclear.' },
+      units: {
+        type: 'array',
+        description: 'Brigades / agencies that attended, with their role if mentioned.',
+        items: {
+          type: 'object',
+          properties: { unit: { type: 'string' }, role: { type: 'string' } },
+          required: ['unit', 'role'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['title', 'location', 'incidentType', 'units'],
+    additionalProperties: false,
+  };
+}
+
+export function buildMetadataMessages({ session, segments }) {
+  const system = `You read the transcript of a fire brigade After Action Review and pull out the basic incident details that were mentioned.
+
+Only report what is actually stated or clearly implied — never invent a title, location, units or type. Use "" (or an empty array) when something is not mentioned. Keep Australian fire-service terminology and unit names as spoken (e.g. "Wamboin", "Bungendore", "FRNSW", "Cat 1"). Mark anything you are unsure of with "(unclear)".
+
+Respond with a JSON object: {"title", "location", "incidentType", "units": [{"unit", "role"}]}.`;
+  const lines = segments.map((seg) => `${seg.speaker ? seg.speaker + ': ' : ''}${seg.text}`);
+  const user = `From this debrief transcript, extract the incident details:\n\n${lines.join('\n')}`;
+  return [
+    { role: 'system', content: system },
+    { role: 'user', content: user },
+  ];
+}
+
+/**
+ * Build a non-destructive patch: only fields the user (or a previous pass) hasn't
+ * already filled get the discussion-derived value. Returns { incident?, units? }
+ * with just the keys that should change, or {} if nothing to apply.
+ */
+export function mergeMetadata(session, meta = {}) {
+  const patch = {};
+  const incident = {};
+  if (meta.title?.trim() && !session.incident.title?.trim()) incident.title = meta.title.trim();
+  if (meta.location?.trim() && !session.incident.location?.trim()) incident.location = meta.location.trim();
+  if (meta.incidentType && INCIDENT_TYPES.includes(meta.incidentType) && !session.incident.type) incident.type = meta.incidentType;
+  if (Object.keys(incident).length) patch.incident = incident;
+  const units = (Array.isArray(meta.units) ? meta.units : [])
+    .map((u) => ({ unit: String(u.unit ?? '').trim(), role: String(u.role ?? '').trim() }))
+    .filter((u) => u.unit);
+  if (units.length && !(session.units ?? []).length) patch.units = units;
+  return patch;
+}
+
+/** Ask the model for the incident metadata mentioned across the transcript. */
+export async function extractMetadata({ session, segments, settings, fetchImpl = globalThis.fetch }) {
+  const usable = (segments ?? []).filter((s) => s.text.trim());
+  if (!usable.length) return {};
+  // One call over a representative slice (metadata is usually said up front).
+  let words = 0;
+  const slice = [];
+  for (const seg of usable) {
+    slice.push(seg);
+    words += countWords(seg.text);
+    if (words > 1200) break;
+  }
+  const result = await chatJson({
+    settings,
+    deployment: settings.llmDeployment,
+    messages: buildMetadataMessages({ session, segments: slice }),
+    schema: metadataSchema(),
+    schemaName: 'aar_metadata',
+    fetchImpl,
+  });
+  return result ?? {};
 }
 
 /**

--- a/aar-studio/js/lib/model.js
+++ b/aar-studio/js/lib/model.js
@@ -1,6 +1,6 @@
 // Session data model: factories, constants and import validation. Pure.
 
-import { uid } from './text.js';
+import { uid, friendlyDateTime } from './text.js';
 
 export const SCHEMA_VERSION = 1;
 export const GENERAL_PHASE = 'General';
@@ -50,6 +50,18 @@ export function createSegment({ t = null, speaker = '', text = '', phase = GENER
 export function createFinding({ category, phase = GENERAL_PHASE, text = '', quote = '', segmentIds = [], source = 'manual' }) {
   if (!CATEGORY_IDS.includes(category)) category = 'happened';
   return { id: uid(), category, phase, text, quote, segmentIds, source, createdAt: new Date().toISOString() };
+}
+
+/**
+ * What to show as a review's name. Real incident title if the user (or the AI)
+ * has one; otherwise a friendly fallback from when it was started, so a review
+ * is never shown as "Untitled". `created` is the session's createdAt.
+ */
+export function displayTitle(session) {
+  const title = session?.incident?.title?.trim();
+  if (title) return title;
+  const created = session?.createdAt ? new Date(session.createdAt) : new Date();
+  return `Review — ${friendlyDateTime(created)}`;
 }
 
 /** Phases available for tagging: configured phases + the implicit General bucket. */

--- a/aar-studio/js/lib/text.js
+++ b/aar-studio/js/lib/text.js
@@ -44,3 +44,30 @@ export function uid() {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
   return 'id-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
 }
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** A Date → the value an <input type="date"> expects (local date, "YYYY-MM-DD"). */
+export function toDateInput(date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Friendly date for display, e.g. "20 Jun 2026". Accepts a Date or "YYYY-MM-DD". */
+export function friendlyDate(value) {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return `${date.getDate()} ${MONTHS[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+/** Friendly date + time, e.g. "20 Jun 2026, 3:42pm". */
+export function friendlyDateTime(date = new Date()) {
+  let h = date.getHours();
+  const min = String(date.getMinutes()).padStart(2, '0');
+  const ampm = h < 12 ? 'am' : 'pm';
+  h = h % 12 || 12;
+  return `${friendlyDate(date)}, ${h}:${min}${ampm}`;
+}

--- a/aar-studio/js/main.js
+++ b/aar-studio/js/main.js
@@ -2,6 +2,7 @@
 
 import { h, clear } from './ui.js';
 import * as store from './store.js';
+import { displayTitle } from './lib/model.js';
 import { openSettingsDialog } from './settings.js';
 import * as home from './views/home.js';
 import * as setup from './views/setup.js';
@@ -11,11 +12,11 @@ import * as review from './views/review.js';
 import * as report from './views/report.js';
 
 const ROUTES = [
-  { hash: '#/home', label: 'Sessions', view: home, always: true },
-  { hash: '#/setup', label: 'Setup', view: setup },
-  { hash: '#/capture', label: 'Capture', view: capture },
-  { hash: '#/board', label: 'Board', view: board },
-  { hash: '#/review', label: 'Review', view: review },
+  { hash: '#/home', label: 'Reviews', view: home, always: true },
+  { hash: '#/setup', label: 'Details', view: setup },
+  { hash: '#/capture', label: 'Record', view: capture },
+  { hash: '#/board', label: 'Findings', view: board },
+  { hash: '#/review', label: 'Edit', view: review },
   { hash: '#/report', label: 'Report', view: report },
 ];
 
@@ -37,7 +38,7 @@ function renderNav() {
     }, r.label));
   }
   nav.append(h('button', { class: 'nav__settings', title: 'Settings', 'aria-label': 'Settings', onclick: openSettingsDialog }, '⚙'));
-  sessionLabel.textContent = session ? (session.incident.title || 'Untitled AAR') : '';
+  sessionLabel.textContent = session ? displayTitle(session) : '';
 }
 
 function render() {

--- a/aar-studio/js/store.js
+++ b/aar-studio/js/store.js
@@ -2,6 +2,7 @@
 // mutation, tiny pub/sub so views can re-render on structural changes.
 
 import { createSession, normaliseSession } from './lib/model.js';
+import { toDateInput } from './lib/text.js';
 
 const SESSION_PREFIX = 'aarstudio.session.';
 const LAST_KEY = 'aarstudio.lastSession';
@@ -53,6 +54,43 @@ export function newSession() {
   return current;
 }
 
+/**
+ * Start a review with the least possible friction: today's date pre-set, the
+ * title/location/units left blank so the AI can fill them from the discussion.
+ * The caller jumps straight to capture and starts the mic.
+ */
+export function quickStart() {
+  const today = toDateInput(new Date());
+  current = createSession({
+    incident: { title: '', date: today, location: '', type: '' },
+    aar: { date: today, location: '', facilitator: '' },
+  });
+  persist();
+  notify('session-loaded');
+  return current;
+}
+
+/** Best-effort device location (e.g. from geolocation); never overwrites a value. */
+export function setIncidentLocation(location) {
+  if (!current || !location || current.incident.location?.trim()) return;
+  update((s) => { s.incident.location = location; }, { reason: 'session' });
+}
+
+/** Rename the current or a given session's incident title. */
+export function renameSession(id, title) {
+  if (current?.id === id) {
+    update((s) => { s.incident.title = title; }, { reason: 'session' });
+    return;
+  }
+  const raw = localStorage.getItem(SESSION_PREFIX + id);
+  if (!raw) return;
+  const s = normaliseSession(JSON.parse(raw));
+  s.incident.title = title;
+  s.updatedAt = new Date().toISOString();
+  localStorage.setItem(SESSION_PREFIX + id, JSON.stringify(s));
+  notify('session-loaded');
+}
+
 export function openSession(id) {
   const raw = localStorage.getItem(SESSION_PREFIX + id);
   if (!raw) throw new Error('Session not found');
@@ -87,8 +125,10 @@ export function listSessions() {
       const s = JSON.parse(localStorage.getItem(key));
       sessions.push({
         id: s.id,
-        title: s.incident?.title || 'Untitled AAR',
+        title: s.incident?.title || '',
+        location: s.incident?.location || '',
         incidentDate: s.incident?.date || '',
+        createdAt: s.createdAt || s.updatedAt || '',
         updatedAt: s.updatedAt || '',
         findings: s.findings?.length ?? 0,
         segments: s.segments?.length ?? 0,

--- a/aar-studio/js/views/capture.js
+++ b/aar-studio/js/views/capture.js
@@ -1,13 +1,17 @@
-// Capture: live listen (mic / shared tab / file via Azure AI Speech),
-// phase clicker, transcript paste ingest, segment list, AI analysis.
+// Capture: just listen. Live transcription + automatic finding extraction —
+// no phase clicking, no manual "analyse". The room talks; findings appear.
 
 import { h, toast, confirmDanger, pickFile } from '../ui.js';
 import * as store from '../store.js';
 import { analyseNow } from '../analyse.js';
 import * as live from '../audio/live.js';
-import { sessionPhases, createSegment, speakerName, GENERAL_PHASE } from '../lib/model.js';
+import { createSegment, speakerName, displayTitle, GENERAL_PHASE } from '../lib/model.js';
 import { parseTranscript } from '../lib/transcriptParser.js';
 import { fmtClock } from '../lib/text.js';
+
+// Quick kick-off asks Capture to start a source as soon as it mounts.
+let pendingAutoStart = null;
+export function requestAutoStart(kind = 'mic') { pendingAutoStart = kind; }
 
 function ingestPaste(textarea) {
   const raw = textarea.value;
@@ -17,7 +21,7 @@ function ingestPaste(textarea) {
   }
   const { format, rows } = parseTranscript(raw);
   if (!rows.length) {
-    toast('Could not find any transcript lines in the pasted text', 'error');
+    toast('Couldn’t find any conversation in that text', 'error');
     return;
   }
   store.update((s) => {
@@ -26,42 +30,39 @@ function ingestPaste(textarea) {
     }
   }, { reason: 'segments' });
   textarea.value = '';
-  toast(`Added ${rows.length} segment(s) (detected format: ${format})`);
+  toast(`Added ${rows.length} line(s) (${format})`);
+  analyseNow(null, { quiet: true });
 }
 
-function audioPanel(status) {
+function audioPanel() {
   const ls = live.getState();
-  const backupCheck = h('input', { type: 'checkbox', checked: true });
+  const findingCount = store.getSession().findings.length;
 
-  const startBtn = (kind, onclick) => h('button', {
-    class: 'btn btn--big',
+  const startBtn = (kind, primary = false) => h('button', {
+    class: `btn ${primary ? 'btn--primary btn--hero' : 'btn--big'}`,
     disabled: ls.status !== 'idle',
-    onclick,
-  }, `${live.SOURCES[kind].icon} ${live.SOURCES[kind].label}`);
+    onclick: kind === 'file'
+      ? async () => { const file = await pickFile('audio/*'); if (file) live.start('file', { file }); }
+      : () => live.start(kind, { backup: true }),
+  }, `${live.SOURCES[kind].icon} ${kind === 'mic' ? 'Start recording the room' : live.SOURCES[kind].label}`);
 
   const idleControls = h('div', {},
-    h('div', { class: 'btn-row' },
-      startBtn('mic', () => live.start('mic', { backup: backupCheck.checked })),
-      startBtn('display', () => live.start('display', { backup: backupCheck.checked })),
-      startBtn('file', async () => {
-        const file = await pickFile('audio/*');
-        if (file) live.start('file', { file });
-      }),
+    h('div', { class: 'capture-start' }, startBtn('mic', true)),
+    h('details', { class: 'more-ways' },
+      h('summary', {}, 'Other ways to capture'),
+      h('div', { class: 'btn-row' }, startBtn('display'), startBtn('file')),
+      h('p', { class: 'muted' }, 'Share a Teams meeting tab (tick “Share audio”), or upload a recording you already have. Diarisation and language live in ⚙ Settings.'),
     ),
-    h('label', { class: 'field field--check' }, backupCheck,
-      h('span', {}, 'Keep a local backup recording (offered as a download when you stop)')),
-    h('p', { class: 'muted' },
-      'Room microphone is the primary mode — one mic, many speakers; diarization and language are set in ⚙ Settings. For a Teams meeting, share the meeting tab and tick “Share audio”.'),
   );
 
-  // Live elements updated directly by the controller (no re-render per frame)
+  // Live elements updated directly by the controller (no re-render per frame).
   const meterBar = h('div', { class: 'meter__bar' });
   const meter = h('div', { class: 'meter', title: 'Input level' }, meterBar);
   const elapsed = h('span', { class: 'live__elapsed' }, '0:00');
   const interimEl = h('div', { class: 'live__interim', 'aria-live': 'off' });
   const stateText = ls.status === 'starting' ? 'Connecting…'
-    : ls.status === 'stopping' ? 'Stopping…'
-    : `Listening — ${live.SOURCES[ls.source]?.label ?? ''}`;
+    : ls.status === 'stopping' ? 'Wrapping up…'
+    : 'Listening — talk naturally';
 
   const liveControls = h('div', { class: 'live' },
     h('div', { class: 'live__row' },
@@ -69,14 +70,16 @@ function audioPanel(status) {
       h('span', { class: 'live__state' }, stateText),
       elapsed,
       meter,
-      h('button', { class: 'btn btn--danger', disabled: ls.status !== 'listening', onclick: () => live.stop() }, '■ Stop listening'),
+      h('button', { class: 'btn btn--primary', disabled: ls.status !== 'listening', onclick: () => live.stop() }, '■ Stop & see findings'),
     ),
+    h('p', { class: 'live__progress muted' }, findingCount
+      ? `${findingCount} finding${findingCount === 1 ? '' : 's'} so far — they keep appearing as you talk.`
+      : 'Findings appear automatically once there’s enough to go on.'),
     interimEl,
-    ls.recording ? h('p', { class: 'muted' }, '● Local backup recording in progress') : null,
+    ls.recording ? h('p', { class: 'muted' }, '● Keeping a local backup recording') : null,
   );
 
-  const panel = h('section', { class: 'panel' },
-    h('h2', {}, 'Live listen'),
+  const panel = h('section', { class: 'panel panel--capture' },
     ls.status === 'idle' ? idleControls : liveControls,
     ls.recordingUrl && ls.status === 'idle'
       ? h('p', {}, h('a', { class: 'btn', href: ls.recordingUrl, download: ls.recordingName }, '⬇ Download backup recording'))
@@ -84,9 +87,6 @@ function audioPanel(status) {
     ls.error ? h('p', { class: 'live__error', role: 'alert' }, ls.error) : null,
   );
 
-  // High-frequency updates touch the DOM directly; anything structural
-  // (status flips, errors) re-renders the view, which rebuilds this panel
-  // from live.getState() and re-registers this listener with fresh nodes.
   live.setUiListener((event, s) => {
     if (event === 'level') {
       meterBar.style.setProperty('--level', String(Math.min(1, s.level * 6)));
@@ -103,72 +103,59 @@ function audioPanel(status) {
 
 export function render(container) {
   const session = store.getSession();
-  const phases = sessionPhases(session);
-  const status = h('span', { class: 'muted' });
+  const ls = live.getState();
 
-  const phaseButtons = h('div', { class: 'phase-clicker', role: 'group', 'aria-label': 'Current phase' },
-    phases.map((p) => h('button', {
-      class: `phase-btn${session.currentPhase === p ? ' phase-btn--active' : ''}`,
-      onclick: () => {
-        store.update((s) => { s.currentPhase = p; }, { reason: 'phase' });
-        // Phase change is an extraction trigger.
-        analyseNow(status, { quiet: true });
-      },
-    }, p)),
-  );
-
-  const pasteBox = h('textarea', {
-    class: 'paste-box',
-    rows: 8,
-    placeholder: 'Paste a Teams transcript here…\nSupported: the DOCX copy format ("Name   m:ss" then text), "Name: text" lines, or WEBVTT.',
-  });
+  // Quick kick-off (or a fresh return) asked us to start a source automatically.
+  if (pendingAutoStart && ls.status === 'idle') {
+    const kind = pendingAutoStart;
+    pendingAutoStart = null;
+    live.start(kind, { backup: true });
+  }
 
   const segments = session.segments;
-  const segmentList = segments.length
+  const transcript = segments.length
     ? h('ol', { class: 'segments' }, segments.slice(-200).map((seg) => h('li', { class: 'segment' },
         h('span', { class: 'segment__meta' },
           seg.t != null ? h('span', { class: 'segment__time' }, fmtClock(seg.t)) : null,
           seg.speaker ? h('span', { class: 'segment__speaker' }, speakerName(session, seg.speaker)) : null,
-          h('span', { class: `chip chip--phase` }, seg.phase),
-          seg.analysed ? h('span', { class: 'chip chip--done', title: 'Included in an AI analysis pass' }, '✓ analysed') : null,
         ),
         h('span', { class: 'segment__text' }, seg.text),
       )))
-    : h('p', { class: 'muted' }, 'No transcript yet. Start live listening above, or paste a transcript below.');
+    : h('p', { class: 'muted' }, 'Nothing captured yet. Start recording above — what’s said appears here.');
 
   container.append(
-    h('h1', {}, 'Live capture'),
-    h('section', { class: 'panel' },
-      h('h2', {}, 'Current phase'),
-      h('p', { class: 'muted' }, 'Click the phase as the room moves through it — new segments are tagged with it, and changing phase triggers an analysis pass.'),
-      phaseButtons,
+    h('div', { class: 'capture-head' },
+      h('h1', {}, displayTitle(session)),
+      h('a', { class: 'btn', href: '#/board' }, session.findings.length ? `See findings (${session.findings.length}) →` : 'Findings →'),
     ),
-    audioPanel(status),
+    audioPanel(),
     h('section', { class: 'panel' },
-      h('h2', {}, 'Paste a transcript'),
-      pasteBox,
-      h('div', { class: 'btn-row' },
-        h('button', { class: 'btn btn--primary', onclick: () => ingestPaste(pasteBox) }, 'Parse & add segments'),
-        h('button', { class: 'btn', onclick: () => analyseNow(status) }, '✨ Analyse with AI now'),
-        status,
-      ),
-    ),
-    h('section', { class: 'panel' },
-      h('h2', {}, `Transcript (${segments.length} segments)`),
-      segmentList,
+      h('h2', {}, `What was said${segments.length ? ` (${segments.length})` : ''}`),
+      transcript,
       segments.length ? h('div', { class: 'btn-row' },
-        h('a', { class: 'btn btn--primary', href: '#/board' }, 'Open the live board →'),
-        h('button', { class: 'btn btn--danger', onclick: () => {
-          if (confirmDanger('Clear ALL transcript segments? Findings are kept.')) {
+        h('button', { class: 'btn btn--small', title: 'Re-check for findings now', onclick: () => analyseNow(null) }, '↻ Update findings now'),
+        h('button', { class: 'btn btn--small btn--danger', onclick: () => {
+          if (confirmDanger('Clear everything that was captured? Findings are kept.')) {
             store.update((s) => { s.segments = []; }, { reason: 'segments' });
           }
         } }, 'Clear transcript'),
       ) : null,
     ),
+    h('details', { class: 'paste-section' },
+      h('summary', {}, 'Add a typed or pasted transcript instead'),
+      h('p', { class: 'muted' }, 'Already have a Teams transcript? Paste it here (the copied chat, “Name: text” lines, or a WEBVTT file).'),
+      (() => {
+        const pasteBox = h('textarea', { class: 'paste-box', rows: 6, placeholder: 'Paste a transcript here…' });
+        return h('div', {},
+          pasteBox,
+          h('button', { class: 'btn btn--primary', onclick: () => ingestPaste(pasteBox) }, 'Add this transcript'),
+        );
+      })(),
+    ),
   );
 
-  // Auto-scroll the transcript to the latest segment while listening.
-  if (live.getState().status === 'listening' && segments.length) {
+  // Auto-scroll the transcript to the latest line while listening.
+  if (ls.status === 'listening' && segments.length) {
     const list = container.querySelector('.segments');
     if (list) list.scrollTop = list.scrollHeight;
   }

--- a/aar-studio/js/views/home.js
+++ b/aar-studio/js/views/home.js
@@ -1,68 +1,103 @@
-// Home: session list, new session, JSON import, sample session.
+// Home: friendly landing — start a new review or reopen a past one.
 
 import { h, toast, download, pickFile, confirmDanger } from '../ui.js';
 import * as store from '../store.js';
+import { requestAutoStart } from './capture.js';
+import { displayTitle } from '../lib/model.js';
+import { friendlyDate } from '../lib/text.js';
 import { sessionFilename } from '../lib/exports.js';
 
-async function loadSample() {
-  const res = await fetch('./data/sample-session.json');
-  if (!res.ok) throw new Error(`Sample not found (${res.status})`);
-  store.importSessionJson(await res.text());
-  location.hash = '#/board';
-  toast('Wamboin sample session loaded — explore Board, Review and Report');
+// Quick kick-off: blank review with today's date, jump to capture, start the mic.
+function startRecordingNow() {
+  store.quickStart();
+  // Best-effort device location; the AI fills a named location from the talk later.
+  navigator.geolocation?.getCurrentPosition(
+    (pos) => store.setIncidentLocation(`${pos.coords.latitude.toFixed(4)}, ${pos.coords.longitude.toFixed(4)}`),
+    () => {},
+    { timeout: 5000, maximumAge: 600000 },
+  );
+  requestAutoStart('mic');
+  location.hash = '#/capture';
 }
 
-async function importJson() {
+function setUpFirst() {
+  store.newSession();
+  location.hash = '#/setup';
+}
+
+async function loadExample() {
+  const res = await fetch('./data/sample-session.json');
+  if (!res.ok) throw new Error(`Example not available (${res.status})`);
+  store.importSessionJson(await res.text());
+  location.hash = '#/board';
+  toast('Loaded an example review — have a look around');
+}
+
+async function openSavedFile() {
   const file = await pickFile('application/json,.json');
   if (!file) return;
   try {
     store.importSessionJson(await file.text());
-    location.hash = '#/setup';
-    toast('Session imported');
+    location.hash = '#/board';
+    toast('Review opened');
   } catch (err) {
-    toast(`Import failed: ${err.message}`, 'error');
+    toast(`Couldn't open that file: ${err.message}`, 'error');
   }
+}
+
+function reviewCard(s) {
+  const subtitle = [friendlyDate(s.incidentDate || s.createdAt), s.location].filter(Boolean).join(' · ');
+  const stat = s.findings
+    ? `${s.findings} finding${s.findings === 1 ? '' : 's'}`
+    : (s.segments ? 'recorded, not yet summarised' : 'empty');
+  return h('article', { class: 'review-card', onclick: () => { store.openSession(s.id); location.hash = '#/board'; } },
+    h('div', { class: 'review-card__body' },
+      h('h3', { class: 'review-card__title' }, displayTitle({ incident: { title: s.title }, createdAt: s.createdAt })),
+      h('p', { class: 'review-card__meta' }, subtitle || 'No details yet'),
+      h('p', { class: 'review-card__stat' }, stat),
+    ),
+    h('div', { class: 'review-card__actions', onclick: (e) => e.stopPropagation() },
+      h('button', { class: 'icon-btn', title: 'Rename', 'aria-label': 'Rename', onclick: () => {
+        const name = prompt('Name this review:', s.title || '');
+        if (name != null) store.renameSession(s.id, name.trim());
+      } }, '✎'),
+      h('button', { class: 'icon-btn', title: 'Save a copy', 'aria-label': 'Save a copy', onclick: () => {
+        const session = store.openSession(s.id);
+        download(sessionFilename(session, 'review', 'json'), store.exportSessionJson(session), 'application/json');
+      } }, '⬇'),
+      h('button', { class: 'icon-btn icon-btn--danger', title: 'Delete', 'aria-label': 'Delete', onclick: () => {
+        if (confirmDanger(`Delete "${displayTitle({ incident: { title: s.title }, createdAt: s.createdAt })}"? This can't be undone.`)) {
+          store.deleteSession(s.id);
+          toast('Review deleted');
+        }
+      } }, '🗑'),
+    ),
+  );
 }
 
 export function render(container) {
   const sessions = store.listSessions();
 
   container.append(
-    h('section', { class: 'hero' },
-      h('h1', {}, 'AAR Studio'),
-      h('p', {}, 'Facilitate, live-present and package After Action Reviews for fire brigade incidents. Everything stays in this browser; AI calls go straight to your Azure resources.'),
+    h('section', { class: 'hero hero--home' },
+      h('h1', {}, 'After Action Reviews, made easy'),
+      h('p', {}, 'Record your crew’s debrief and get a clear write-up — who attended, what happened, what went well, and what to do next time. Just talk; the app does the rest.'),
       h('div', { class: 'hero__actions' },
-        h('button', { class: 'btn btn--primary btn--big', onclick: () => { store.newSession(); location.hash = '#/setup'; } }, 'New AAR session'),
-        h('button', { class: 'btn btn--big', onclick: importJson }, 'Import session JSON'),
-        h('button', { class: 'btn btn--big', onclick: () => loadSample().catch((e) => toast(e.message, 'error')) }, 'Load Wamboin sample'),
+        h('button', { class: 'btn btn--primary btn--hero', onclick: startRecordingNow }, '🎙 Start recording now'),
+        h('button', { class: 'btn btn--big', onclick: setUpFirst }, 'Set up a review first'),
       ),
+      h('p', { class: 'hero__hint' }, 'No setup needed — start talking and the title, location and crews are picked up from the conversation. You can edit anything afterwards.'),
     ),
-    h('section', {},
-      h('h2', {}, 'Saved sessions'),
+    h('section', { class: 'reviews' },
+      h('h2', {}, 'Your reviews'),
       sessions.length
-        ? h('table', { class: 'table' },
-            h('thead', {}, h('tr', {}, h('th', {}, 'Incident'), h('th', {}, 'Incident date'), h('th', {}, 'Findings'), h('th', {}, 'Segments'), h('th', {}, 'Updated'), h('th', {}, ''))),
-            h('tbody', {}, sessions.map((s) => h('tr', {},
-              h('td', {}, h('a', { href: '#/board', onclick: () => store.openSession(s.id) }, s.title)),
-              h('td', {}, s.incidentDate),
-              h('td', {}, String(s.findings)),
-              h('td', {}, String(s.segments)),
-              h('td', {}, s.updatedAt ? new Date(s.updatedAt).toLocaleString() : ''),
-              h('td', { class: 'table__actions' },
-                h('button', { class: 'btn btn--small', onclick: () => {
-                  const session = store.openSession(s.id);
-                  download(sessionFilename(session, 'session', 'json'), store.exportSessionJson(session), 'application/json');
-                } }, 'Export'),
-                h('button', { class: 'btn btn--small btn--danger', onclick: () => {
-                  if (confirmDanger(`Delete "${s.title}"? This cannot be undone (export it first if unsure).`)) {
-                    store.deleteSession(s.id);
-                    toast('Session deleted');
-                  }
-                } }, 'Delete'),
-              ),
-            ))),
-          )
-        : h('p', { class: 'muted' }, 'No sessions yet. Start one, or load the Wamboin sample to see a finished AAR.'),
+        ? h('div', { class: 'review-grid' }, sessions.map(reviewCard))
+        : h('p', { class: 'muted' }, 'No reviews yet. Hit “Start recording now” at the end of your next job.'),
+    ),
+    h('section', { class: 'home-footer' },
+      h('button', { class: 'link-btn', onclick: () => loadExample().catch((e) => toast(e.message, 'error')) }, 'See an example'),
+      h('span', { class: 'home-footer__sep' }, '·'),
+      h('button', { class: 'link-btn', onclick: openSavedFile }, 'Open a saved review file'),
     ),
   );
 }

--- a/aar-studio/js/views/setup.js
+++ b/aar-studio/js/views/setup.js
@@ -37,11 +37,13 @@ export function render(container) {
   );
 
   container.append(
-    h('h1', {}, 'Session setup'),
+    h('h1', {}, 'Review details'),
+    h('p', { class: 'muted setup-intro' },
+      'All optional — you can leave any of this blank and the app will fill in the title, location and crews from the discussion. Edit anything here or later.'),
     h('div', { class: 'form-grid' },
       h('fieldset', {},
         h('legend', {}, 'Incident'),
-        field('Title', text(s.incident.title, (sess, v) => { sess.incident.title = v; }, { placeholder: 'e.g. Wamboin Structure Fire — 412 Macs Reef Road' })),
+        field('Title', text(s.incident.title, (sess, v) => { sess.incident.title = v; }, { placeholder: 'e.g. Structure fire — 12 Smith St (or leave blank)' })),
         field('Date', h('input', { type: 'date', value: s.incident.date, ...bind(null, (sess, v) => { sess.incident.date = v; }) })),
         field('Location', text(s.incident.location, (sess, v) => { sess.incident.location = v; })),
         field('Type', h('select', {
@@ -64,13 +66,14 @@ export function render(container) {
       ),
       h('button', { class: 'btn', onclick: () => store.update((sess) => sess.units.push({ unit: '', role: '' })) }, '+ Add unit'),
     ),
-    h('fieldset', {},
-      h('legend', {}, 'Incident phases'),
+    h('details', { class: 'advanced' },
+      h('summary', {}, 'Advanced: incident phases'),
+      h('p', { class: 'muted' }, 'The AI groups findings into these phases automatically — you only need to change them for an unusual job.'),
       phaseList,
       h('button', { class: 'btn', onclick: () => store.update((sess) => sess.phases.push('')) }, '+ Add phase'),
     ),
     h('div', { class: 'page-actions' },
-      h('button', { class: 'btn btn--primary', onclick: () => { toast('Saved'); location.hash = '#/capture'; } }, 'Continue to Capture →'),
+      h('button', { class: 'btn btn--primary btn--big', onclick: () => { toast('Saved'); location.hash = '#/capture'; } }, 'Start recording →'),
     ),
   );
 }

--- a/aar-studio/test/friendlyFlow.test.js
+++ b/aar-studio/test/friendlyFlow.test.js
@@ -1,0 +1,69 @@
+// Tests for the friendly, non-technical AAR flow: date/title helpers, the
+// display-title fallback, and the non-destructive "fill metadata from the
+// discussion" merge.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { toDateInput, friendlyDate, friendlyDateTime } from '../js/lib/text.js';
+import { createSession, displayTitle } from '../js/lib/model.js';
+import { metadataSchema, mergeMetadata } from '../js/lib/extraction.js';
+
+test('toDateInput renders a local YYYY-MM-DD for <input type=date>', () => {
+  assert.equal(toDateInput(new Date(2026, 5, 20, 15, 42)), '2026-06-20');
+  assert.equal(toDateInput(new Date(2026, 0, 3)), '2026-01-03');
+});
+
+test('friendlyDate accepts a Date or an input-date string', () => {
+  assert.equal(friendlyDate(new Date(2026, 5, 20)), '20 Jun 2026');
+  assert.equal(friendlyDate('2026-06-20'), '20 Jun 2026');
+  assert.equal(friendlyDate(''), '');
+});
+
+test('friendlyDateTime renders 12-hour am/pm', () => {
+  assert.equal(friendlyDateTime(new Date(2026, 5, 20, 15, 42)), '20 Jun 2026, 3:42pm');
+  assert.equal(friendlyDateTime(new Date(2026, 5, 20, 0, 5)), '20 Jun 2026, 12:05am');
+  assert.equal(friendlyDateTime(new Date(2026, 5, 20, 12, 0)), '20 Jun 2026, 12:00pm');
+});
+
+test('displayTitle uses the incident title, else a friendly fallback', () => {
+  const titled = createSession({ incident: { title: 'Structure fire — 12 Smith St', date: '', location: '', type: '' } });
+  assert.equal(displayTitle(titled), 'Structure fire — 12 Smith St');
+
+  const blank = createSession({ createdAt: new Date(2026, 5, 20, 15, 42).toISOString() });
+  assert.match(displayTitle(blank), /^Review — 20 Jun 2026, 3:42pm$/);
+});
+
+test('mergeMetadata only fills blanks — never overwrites the user', () => {
+  const session = createSession({
+    incident: { title: 'My own title', date: '', location: '', type: '' },
+    units: [],
+  });
+  const meta = {
+    title: 'AI suggested title',                 // ignored — user set a title
+    location: 'Wamboin',                          // applied — was blank
+    incidentType: 'Structure Fire',               // applied — valid + blank
+    units: [{ unit: 'Wamboin', role: 'First in' }],
+  };
+  const patch = mergeMetadata(session, meta);
+  assert.equal(patch.incident.title, undefined, 'does not overwrite the user title');
+  assert.equal(patch.incident.location, 'Wamboin');
+  assert.equal(patch.incident.type, 'Structure Fire');
+  assert.deepEqual(patch.units, [{ unit: 'Wamboin', role: 'First in' }]);
+});
+
+test('mergeMetadata ignores empty/unknown values and pre-filled units', () => {
+  const session = createSession({
+    incident: { title: '', date: '', location: 'Set already', type: '' },
+    units: [{ unit: 'Existing', role: '' }],
+  });
+  const patch = mergeMetadata(session, { title: '', location: 'New', incidentType: 'Nonsense', units: [{ unit: 'X', role: '' }] });
+  assert.equal(patch.incident, undefined, 'nothing valid to fill (title empty, location taken, type invalid)');
+  assert.equal(patch.units, undefined, 'units already present — left alone');
+});
+
+test('metadataSchema constrains incidentType to known values plus empty', () => {
+  const schema = metadataSchema();
+  assert.ok(schema.properties.incidentType.enum.includes(''));
+  assert.ok(schema.properties.incidentType.enum.includes('Structure Fire'));
+  assert.deepEqual(schema.required, ['title', 'location', 'incidentType', 'units']);
+});


### PR DESCRIPTION
## Why

AAR Studio presented too "technical" for its actual users — a wall of form fields, manual phase-clicking, a manual "analyse" button, and developer jargon like "Import session JSON". This reworks the architecture and workflow around a **non-technical facilitator**: just talk, and the app does the heavy lifting, with the user able to intervene anywhere.

## The new flow

1. **Home** — plain-language landing with two paths: **"Start recording now"** (quick kick-off) and an optional **"Set up a review first"**. Past reviews are friendly cards (title / date / location / findings) with rename / save / delete — not a technical table. "Import JSON" and "Load Wamboin sample" are gone from the foreground, demoted to a quiet footer: *"Open a saved review file"* / *"See an example"*.
2. **Quick kick-off** — one tap creates a review with today's date/time (+ best-effort device location), leaves the title/location/crews blank for the AI, jumps straight to capture, and **auto-starts the room mic**.
3. **Capture** — **no phase clicker, no manual "analyse"**. Findings appear automatically as people talk (friendly "N findings so far" status), and the AI works out each finding's phase. Primary action is **"Stop & see findings"**. Pasting a transcript is still supported but tucked into an optional collapsible. Transcript relabelled "What was said".
4. **Metadata from the discussion** — on stop, the AI fills any **blank** incident details (title, location, attending crews, type) from what was said — **non-destructively**, never overwriting anything the user typed.
5. **Setup** is now fully optional (generic placeholder — no Wamboin prefill wording; phases collapsed under "Advanced"). Nav relabelled to plain words: Reviews / Details / Record / Findings / Edit / Report. A review is never shown as "Untitled" (friendly `displayTitle` fallback).

## What didn't change

The board, review, and report views still let the user intervene — recategorise, rephase, edit transcript, rename speakers, quick-add — they're just no longer *required* steps.

## Implementation notes

- New **pure** helpers (unit-tested): `text.toDateInput/friendlyDate/friendlyDateTime`, `model.displayTitle`, `extraction.extractMetadata/mergeMetadata/metadataSchema`, `store.quickStart/renameSession`, `analyse.fillMetadataFromDiscussion`.
- **7 new `node --test` cases; 44 total, all pass.** All modules pass `node --check`.
- Frontend-only (no build step). Device geolocation is best-effort; to actually enable it on `/aar`, add `geolocation=(self)` to the scoped Permissions-Policy in `backend/src/index.ts` — small, separate, not in this PR.

## Test plan (needs a browser + mic)

- [x] `cd aar-studio && npm test` → 44/44
- [ ] Home → **Start recording now** → lands in Record, mic starts, transcript fills, findings appear without any clicking
- [ ] **Stop & see findings** → blank incident details get filled from the talk; findings have sensible phases
- [ ] Home shows the review as a friendly card; rename / delete / open work
- [ ] **Set up a review first** still works; **See an example** loads the sample

https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S)_