### PR TITLE
feat: Stripe billing — checkout, webhook, portal, upgrade UI (#553)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,6 +27,7 @@
         "multer": "^2.2.0",
         "papaparse": "^5.5.3",
         "socket.io": "^4.8.1",
+        "stripe": "^22.2.2",
         "uuid": "^14.0.0",
         "winston": "^3.19.0"
       },
@@ -8955,6 +8956,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.2.tgz",
+      "integrity": "sha512-lRXLiarjW/I2QVa6QuFfz1Ma7Dc2yBQ7vlYH6NEmp5htMJNQGfiWExmOv0McfqY5wMCGV8DLuCvsyVRIPJlUUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
     "multer": "^2.2.0",
     "papaparse": "^5.5.3",
     "socket.io": "^4.8.1",
+    "stripe": "^22.2.2",
     "uuid": "^14.0.0",
     "winston": "^3.19.0"
   },

--- a/backend/src/__tests__/billing.test.ts
+++ b/backend/src/__tests__/billing.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Billing route + stripeClient unit/integration tests.
+ *
+ * Tests cover all paths that do NOT require a live Stripe connection:
+ * error-path returns (503, 400, 401), helper function behaviour,
+ * and the billing status endpoint.
+ *
+ * Paths that call stripe.checkout.sessions.create / billingPortal / webhooks
+ * with a real signature are exercised via end-to-end / manual test only.
+ */
+
+import request from 'supertest';
+import express from 'express';
+import authRouter from '../routes/auth';
+import organizationsRouter from '../routes/organizations';
+import billingRouter from '../routes/billing';
+import { ensureOrganizationDatabase, initializeOrganizationDatabase } from '../services/organizationDbFactory';
+import { ensureAdminUserDatabase, initializeAdminUserDatabase, getAdminDb } from '../services/adminUserDbFactory';
+
+function buildApp() {
+  const app = express();
+  // Must be before express.json() — mirrors what index.ts does.
+  app.use('/api/billing/webhook', express.raw({ type: 'application/json' }));
+  app.use(express.json());
+  app.use('/api/auth', authRouter);
+  app.use('/api/organizations', organizationsRouter);
+  app.use('/api/billing', billingRouter);
+  return app;
+}
+
+describe('Billing', () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    await initializeOrganizationDatabase();
+    ensureAdminUserDatabase();
+    await initializeAdminUserDatabase();
+  });
+
+  beforeEach(async () => {
+    await (ensureOrganizationDatabase() as unknown as { clear: () => Promise<void> }).clear();
+    await (getAdminDb() as unknown as { clear: () => Promise<void> }).clear();
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    delete process.env.STRIPE_PRICE_BASIC_MONTHLY;
+    delete process.env.STRIPE_PRICE_BASIC_ANNUAL;
+    delete process.env.STRIPE_PRICE_AI_MONTHLY;
+    delete process.env.STRIPE_PRICE_AI_ANNUAL;
+    app = buildApp();
+  });
+
+  afterAll(() => {
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    delete process.env.STRIPE_PRICE_BASIC_MONTHLY;
+    delete process.env.STRIPE_PRICE_BASIC_ANNUAL;
+    delete process.env.STRIPE_PRICE_AI_MONTHLY;
+    delete process.env.STRIPE_PRICE_AI_ANNUAL;
+  });
+
+  async function signup(overrides: Record<string, unknown> = {}) {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({
+        organizationName: 'Billings RFS',
+        billingEmail: 'billing@rfs.org',
+        username: 'owner',
+        password: 'supersecret1',
+        ...overrides,
+      });
+    return res.body.token as string;
+  }
+
+  // ── stripeClient helpers ───────────────────────────────────────────────────
+
+  describe('stripeClient', () => {
+    // Re-require to avoid cached module state from other test files.
+    function loadStripeClient() {
+      jest.resetModules();
+      return require('../services/stripeClient');
+    }
+
+    it('isStripeConfigured() returns false when STRIPE_SECRET_KEY is absent', () => {
+      delete process.env.STRIPE_SECRET_KEY;
+      const { isStripeConfigured } = loadStripeClient();
+      expect(isStripeConfigured()).toBe(false);
+    });
+
+    it('isStripeConfigured() returns true when STRIPE_SECRET_KEY is set', () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake_key';
+      const { isStripeConfigured } = loadStripeClient();
+      expect(isStripeConfigured()).toBe(true);
+    });
+
+    it('resolvePriceId() returns undefined when env var not set', () => {
+      delete process.env.STRIPE_PRICE_BASIC_MONTHLY;
+      const { resolvePriceId } = loadStripeClient();
+      expect(resolvePriceId('basic', 'monthly')).toBeUndefined();
+    });
+
+    it('resolvePriceId() returns price ID when env var is set', () => {
+      process.env.STRIPE_PRICE_BASIC_MONTHLY = 'price_test_123';
+      const { resolvePriceId } = loadStripeClient();
+      expect(resolvePriceId('basic', 'monthly')).toBe('price_test_123');
+    });
+
+    it('resolvePriceId() returns undefined for unknown plan/interval combo', () => {
+      const { resolvePriceId } = loadStripeClient();
+      expect(resolvePriceId('basic', 'quarterly' as never)).toBeUndefined();
+    });
+
+    it('getStripeClient() throws when STRIPE_SECRET_KEY is not set', () => {
+      delete process.env.STRIPE_SECRET_KEY;
+      const { getStripeClient } = loadStripeClient();
+      expect(() => getStripeClient()).toThrow('STRIPE_SECRET_KEY is not configured');
+    });
+  });
+
+  // ── GET /api/billing/status ────────────────────────────────────────────────
+
+  describe('GET /api/billing/status', () => {
+    it('returns billing summary for an authenticated org user', async () => {
+      const token = await signup();
+      const res = await request(app)
+        .get('/api/billing/status')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.planCode).toBe('community');
+      expect(res.body.status).toBe('active');
+      expect(res.body.trialEndsAt).toBeNull();
+      expect(res.body.hasPaymentMethod).toBe(false);
+      expect(res.body.stripeConfigured).toBe(false);
+    });
+
+    it('returns 401 when not authenticated', async () => {
+      const res = await request(app).get('/api/billing/status');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── POST /api/billing/checkout ─────────────────────────────────────────────
+
+  describe('POST /api/billing/checkout', () => {
+    it('returns 401 when not authenticated', async () => {
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .send({ planCode: 'basic' });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 503 when Stripe is not configured', async () => {
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ planCode: 'basic', billingInterval: 'monthly' });
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/not configured/i);
+    });
+
+    it('returns 400 when planCode is missing', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ billingInterval: 'monthly' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when planCode is "community"', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ planCode: 'community', billingInterval: 'monthly' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when billingInterval is invalid', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ planCode: 'basic', billingInterval: 'weekly' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when price env var is not configured for the chosen plan', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      delete process.env.STRIPE_PRICE_BASIC_MONTHLY;
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ planCode: 'basic', billingInterval: 'monthly' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/STRIPE_PRICE_BASIC_MONTHLY/);
+    });
+
+    it('returns 400 for ai plan when annual env var missing', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      delete process.env.STRIPE_PRICE_AI_ANNUAL;
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/checkout')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ planCode: 'ai', billingInterval: 'annual' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/STRIPE_PRICE_AI_ANNUAL/);
+    });
+  });
+
+  // ── POST /api/billing/portal ───────────────────────────────────────────────
+
+  describe('POST /api/billing/portal', () => {
+    it('returns 401 when not authenticated', async () => {
+      const res = await request(app).post('/api/billing/portal');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 503 when Stripe is not configured', async () => {
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/portal')
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 400 when org has no Stripe customer yet', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      const token = await signup();
+      const res = await request(app)
+        .post('/api/billing/portal')
+        .set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/billing account/i);
+    });
+  });
+
+  // ── POST /api/billing/webhook ──────────────────────────────────────────────
+
+  describe('POST /api/billing/webhook', () => {
+    it('returns 503 when Stripe is not configured', async () => {
+      const res = await request(app)
+        .post('/api/billing/webhook')
+        .set('Content-Type', 'application/json')
+        .send('{}');
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 500 when STRIPE_WEBHOOK_SECRET is missing', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      delete process.env.STRIPE_WEBHOOK_SECRET;
+      const res = await request(app)
+        .post('/api/billing/webhook')
+        .set('Content-Type', 'application/json')
+        .set('Stripe-Signature', 't=1234,v1=sig')
+        .send('{}');
+      expect(res.status).toBe(500);
+    });
+
+    it('returns 400 when Stripe-Signature header is missing', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_fake';
+      const res = await request(app)
+        .post('/api/billing/webhook')
+        .set('Content-Type', 'application/json')
+        .send('{}');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/signature/i);
+    });
+
+    it('returns 400 when Stripe-Signature is invalid', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_fake_secret_here';
+      const res = await request(app)
+        .post('/api/billing/webhook')
+        .set('Content-Type', 'application/json')
+        .set('Stripe-Signature', 't=1234,v1=invalidsignaturehex')
+        .send(Buffer.from('{}'));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/signature/i);
+    });
+  });
+});

--- a/backend/src/constants/plans.ts
+++ b/backend/src/constants/plans.ts
@@ -15,8 +15,12 @@ export interface PlanDefinition {
   name: string;
   /** Display price in AUD per brigade/month. 0 for the free tier. */
   priceMonthlyAud: number;
-  /** Env var holding the Stripe Price ID for this plan (resolved at billing time). */
-  stripePriceEnvVar?: string;
+  /** Display price in AUD per brigade/year (2 months free). 0 for the free tier. */
+  priceAnnualAud: number;
+  /** Env var for the Stripe Price ID used for monthly billing. */
+  stripePriceMonthlyEnvVar?: string;
+  /** Env var for the Stripe Price ID used for annual billing. */
+  stripePriceAnnualEnvVar?: string;
   /** Default entitlements granted by this plan (the ceiling for owner toggles). */
   entitlements: Entitlements;
   description: string;
@@ -27,6 +31,7 @@ export const PLANS: Record<PlanCode, PlanDefinition> = {
     code: 'community',
     name: 'Community',
     priceMonthlyAud: 0,
+    priceAnnualAud: 0,
     entitlements: {
       signInEnabled: true,
       truckCheckEnabled: true,
@@ -36,39 +41,43 @@ export const PLANS: Record<PlanCode, PlanDefinition> = {
       maxDevices: 2,
       aiIncludedSessions: 0,
     },
-    description: 'Free tier for a single station: sign-in book and basic truck checks.',
+    description: 'Free for any brigade. Sign-in book and truck checks. Single-station setup.',
   },
   basic: {
     code: 'basic',
     name: 'Basic',
     priceMonthlyAud: 10,
-    stripePriceEnvVar: 'STRIPE_PRICE_BASIC',
+    priceAnnualAud: 100,
+    stripePriceMonthlyEnvVar: 'STRIPE_PRICE_BASIC_MONTHLY',
+    stripePriceAnnualEnvVar: 'STRIPE_PRICE_BASIC_ANNUAL',
     entitlements: {
       signInEnabled: true,
       truckCheckEnabled: true,
       reportsEnabled: true,
       aiEnabled: false,
-      maxStations: 5,
-      maxDevices: 25,
+      maxStations: 20,
+      maxDevices: 10,
       aiIncludedSessions: 0,
     },
-    description: 'Full manual suite: sign-in, truck checks, reports, CSV export, unlimited members.',
+    description: 'Full manual suite: sign-in, truck checks, reports & CSV export. Unlimited members, up to 10 devices.',
   },
   ai: {
     code: 'ai',
-    name: 'AI (Pro)',
+    name: 'AI Pro',
     priceMonthlyAud: 19,
-    stripePriceEnvVar: 'STRIPE_PRICE_AI',
+    priceAnnualAud: 190,
+    stripePriceMonthlyEnvVar: 'STRIPE_PRICE_AI_MONTHLY',
+    stripePriceAnnualEnvVar: 'STRIPE_PRICE_AI_ANNUAL',
     entitlements: {
       signInEnabled: true,
       truckCheckEnabled: true,
       reportsEnabled: true,
       aiEnabled: true,
-      maxStations: 10,
-      maxDevices: 50,
-      aiIncludedSessions: 25, // fair-use allowance; overage handled via metering (future)
+      maxStations: 20,
+      maxDevices: 25,
+      aiIncludedSessions: 25, // fair-use allowance; overage metering is a future enhancement
     },
-    description: 'Everything in Basic plus the AI voice maintenance agent (fair-use metered).',
+    description: 'Everything in Basic plus AI-powered After Action Reviews via AAR Studio. ~25 sessions/month included.',
   },
 };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,6 +55,7 @@ import brigadeAccessRouter from './routes/brigadeAccess';
 import exportRouter from './routes/export';
 import authRouter from './routes/auth';
 import organizationsRouter from './routes/organizations';
+import billingRouter from './routes/billing';
 import { createAchievementRoutes } from './routes/achievements';
 import { ensureDatabase } from './services/dbFactory';
 import { ensureTruckChecksDatabase } from './services/truckChecksDbFactory';
@@ -194,6 +195,10 @@ app.use(cors({
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Station-Id', 'X-Request-ID'],
 }));
+
+// Stripe webhook needs the raw (unparsed) body to verify its signature.
+// This must be registered before express.json() so the stream is not consumed first.
+app.use('/api/billing/webhook', express.raw({ type: 'application/json' }));
 
 // Middleware
 app.use(express.json());
@@ -374,6 +379,7 @@ app.get('/api/status', apiRateLimiter, async (req, res) => {
 // have AI gated off.
 app.use('/api/auth', apiRateLimiter, authRouter);
 app.use('/api/organizations', apiRateLimiter, organizationsRouter);
+app.use('/api/billing', apiRateLimiter, billingRouter);
 app.use('/api/members', apiRateLimiter, membersRouter);
 app.use('/api/activities', apiRateLimiter, activitiesRouter);
 app.use('/api/checkins', apiRateLimiter, requireFeature('signInEnabled'), checkinsRouter);

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -1,0 +1,331 @@
+/**
+ * Billing Routes — Stripe integration
+ *
+ * POST /api/billing/checkout — create Stripe Checkout session (owner-only)
+ * POST /api/billing/portal  — create Stripe Customer Portal session (owner-only)
+ * GET  /api/billing/status  — current billing status for the org
+ * POST /api/billing/webhook — Stripe webhook (no auth, verified by signature)
+ *
+ * The webhook endpoint must receive a raw (un-parsed) request body.
+ * Register express.raw({ type: 'application/json' }) for this path in index.ts
+ * BEFORE the global express.json() middleware.
+ */
+
+import { Router, Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { getStripeClient, isStripeConfigured, resolvePriceId } from '../services/stripeClient';
+import { authMiddleware, requireOwner } from '../middleware/auth';
+import { ensureOrganizationDatabase } from '../services/organizationDbFactory';
+import { getDefaultEntitlements, isPlanCode } from '../constants/plans';
+import { logger } from '../services/logger';
+import type Stripe from 'stripe';
+import type { BillingEvent, PlanCode, OrganizationStatus } from '../types';
+
+const router = Router();
+
+// In-memory audit log — sufficient for dev/test; replace with Table Storage persistence
+// in a follow-up once the BillingEventStore interface is wired to both DB backends.
+const billingEventLog: BillingEvent[] = [];
+
+function auditBillingEvent(partial: Omit<BillingEvent, 'id' | 'processedAt'>): void {
+  billingEventLog.push({ id: uuidv4(), processedAt: new Date(), ...partial });
+}
+
+function appBaseUrl(): string {
+  const urls = process.env.FRONTEND_URLS || process.env.FRONTEND_URL || 'http://localhost:5173';
+  return urls.split(',')[0].trim().replace(/\/$/, '');
+}
+
+// ─── POST /api/billing/checkout ──────────────────────────────────────────────
+
+router.post('/checkout', authMiddleware, requireOwner, async (req: Request, res: Response) => {
+  if (!isStripeConfigured()) {
+    return res.status(503).json({ error: 'Billing is not configured on this server' });
+  }
+
+  const { planCode, billingInterval = 'monthly' } = req.body ?? {};
+
+  if (!planCode || !isPlanCode(planCode) || planCode === 'community') {
+    return res.status(400).json({ error: 'planCode must be "basic" or "ai"' });
+  }
+  if (billingInterval !== 'monthly' && billingInterval !== 'annual') {
+    return res.status(400).json({ error: 'billingInterval must be "monthly" or "annual"' });
+  }
+
+  const priceId = resolvePriceId(planCode, billingInterval);
+  if (!priceId) {
+    return res.status(400).json({
+      error: `No Stripe price configured for ${planCode}/${billingInterval}. Set STRIPE_PRICE_${planCode.toUpperCase()}_${billingInterval.toUpperCase()} env var.`,
+    });
+  }
+
+  try {
+    const orgDb = ensureOrganizationDatabase();
+    const org = await orgDb.getOrganizationById(req.user!.organizationId!);
+    if (!org) return res.status(404).json({ error: 'Organization not found' });
+
+    const stripe = getStripeClient();
+
+    let customerId = org.stripeCustomerId;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: org.billingEmail,
+        name: org.name,
+        metadata: { organizationId: org.id, slug: org.slug },
+      });
+      customerId = customer.id;
+      await orgDb.updateOrganization(org.id, { stripeCustomerId: customerId });
+    }
+
+    const base = appBaseUrl();
+    const session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: 'subscription',
+      payment_method_types: ['card'],
+      line_items: [{ price: priceId, quantity: 1 }],
+      subscription_data: {
+        trial_period_days: 14,
+        metadata: { organizationId: org.id, planCode },
+      },
+      success_url: `${base}/admin/organization?billing=success`,
+      cancel_url: `${base}/admin/organization?billing=cancelled`,
+      metadata: { organizationId: org.id, planCode },
+      allow_promotion_codes: true,
+      tax_id_collection: { enabled: true },
+      automatic_tax: { enabled: false },
+    });
+
+    logger.info('Stripe Checkout session created', {
+      organizationId: org.id,
+      planCode,
+      interval: billingInterval,
+      sessionId: session.id,
+    });
+
+    return res.json({ checkoutUrl: session.url });
+  } catch (error) {
+    logger.error('Error creating checkout session', { error });
+    return res.status(500).json({ error: 'Failed to create checkout session' });
+  }
+});
+
+// ─── POST /api/billing/portal ────────────────────────────────────────────────
+
+router.post('/portal', authMiddleware, requireOwner, async (req: Request, res: Response) => {
+  if (!isStripeConfigured()) {
+    return res.status(503).json({ error: 'Billing is not configured on this server' });
+  }
+
+  try {
+    const orgDb = ensureOrganizationDatabase();
+    const org = await orgDb.getOrganizationById(req.user!.organizationId!);
+    if (!org) return res.status(404).json({ error: 'Organization not found' });
+    if (!org.stripeCustomerId) {
+      return res.status(400).json({ error: 'No billing account found. Subscribe to a plan first.' });
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.billingPortal.sessions.create({
+      customer: org.stripeCustomerId,
+      return_url: `${appBaseUrl()}/admin/organization`,
+    });
+
+    logger.info('Stripe Customer Portal session created', { organizationId: org.id });
+    return res.json({ portalUrl: session.url });
+  } catch (error) {
+    logger.error('Error creating portal session', { error });
+    return res.status(500).json({ error: 'Failed to create portal session' });
+  }
+});
+
+// ─── GET /api/billing/status ─────────────────────────────────────────────────
+
+router.get('/status', authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const orgDb = ensureOrganizationDatabase();
+    const org = await orgDb.getOrganizationById(req.user?.organizationId ?? '');
+    if (!org) return res.status(404).json({ error: 'Organization not found' });
+
+    return res.json({
+      planCode: org.planCode,
+      status: org.status,
+      trialEndsAt: org.trialEndsAt ?? null,
+      hasPaymentMethod: Boolean(org.stripeCustomerId && org.stripeSubscriptionId),
+      stripeConfigured: isStripeConfigured(),
+    });
+  } catch (error) {
+    logger.error('Error fetching billing status', { error });
+    return res.status(500).json({ error: 'Failed to fetch billing status' });
+  }
+});
+
+// ─── POST /api/billing/webhook ───────────────────────────────────────────────
+// req.body is a raw Buffer — register express.raw() for this path BEFORE
+// express.json() in index.ts so the stream is not consumed by JSON parsing.
+
+router.post('/webhook', async (req: Request, res: Response) => {
+  if (!isStripeConfigured()) {
+    return res.status(503).json({ error: 'Billing not configured' });
+  }
+
+  const sig = req.headers['stripe-signature'];
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    logger.error('STRIPE_WEBHOOK_SECRET env var is missing — cannot verify webhook');
+    return res.status(500).json({ error: 'Webhook secret not configured' });
+  }
+  if (!sig) {
+    return res.status(400).json({ error: 'Missing Stripe-Signature header' });
+  }
+
+  let event: Stripe.Event;
+  try {
+    const stripe = getStripeClient();
+    event = stripe.webhooks.constructEvent(req.body as Buffer, sig, webhookSecret);
+  } catch (err) {
+    logger.warn('Webhook signature verification failed', { error: err });
+    return res.status(400).json({ error: 'Webhook signature verification failed' });
+  }
+
+  logger.info('Stripe webhook received', { type: event.type, id: event.id });
+
+  let processingError: string | undefined;
+  try {
+    await processStripeEvent(event);
+  } catch (error) {
+    processingError = error instanceof Error ? error.message : String(error);
+    logger.error('Error processing Stripe webhook', { type: event.type, eventId: event.id, error });
+  }
+
+  auditBillingEvent({
+    organizationId: extractOrgId(event),
+    stripeEventId: event.id,
+    eventType: event.type,
+    payload: JSON.stringify(event.data.object),
+    error: processingError,
+  });
+
+  // Always return 200 after audit — prevents Stripe from re-delivering.
+  return res.json({ received: true });
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function extractOrgId(event: Stripe.Event): string | undefined {
+  const obj = event.data.object as unknown as Record<string, unknown>;
+  const meta = obj['metadata'] as Record<string, string> | undefined;
+  if (meta?.['organizationId']) return meta['organizationId'];
+
+  const subData = obj['subscription_data'] as Record<string, unknown> | undefined;
+  const subMeta = subData?.['metadata'] as Record<string, string> | undefined;
+  return subMeta?.['organizationId'];
+}
+
+function stripeStatusToOrgStatus(stripeStatus: string): OrganizationStatus {
+  switch (stripeStatus) {
+    case 'active': return 'active';
+    case 'trialing': return 'trialing';
+    case 'past_due': return 'past_due';
+    case 'canceled':
+    case 'unpaid':
+    case 'paused':
+      return 'canceled';
+    default:
+      return 'active';
+  }
+}
+
+async function processStripeEvent(event: Stripe.Event): Promise<void> {
+  const orgDb = ensureOrganizationDatabase();
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const organizationId = session.metadata?.['organizationId'];
+      const planCode = session.metadata?.['planCode'] as PlanCode | undefined;
+      if (!organizationId || !planCode || !isPlanCode(planCode)) {
+        logger.warn('checkout.session.completed missing org/plan metadata', { sessionId: session.id });
+        break;
+      }
+      await orgDb.updateOrganization(organizationId, {
+        planCode,
+        status: 'trialing',
+        stripeCustomerId: typeof session.customer === 'string' ? session.customer : undefined,
+        stripeSubscriptionId: typeof session.subscription === 'string' ? session.subscription : undefined,
+        entitlements: getDefaultEntitlements(planCode),
+      });
+      logger.info('Org upgraded via Checkout', { organizationId, planCode });
+      break;
+    }
+
+    case 'customer.subscription.updated': {
+      const sub = event.data.object as Stripe.Subscription;
+      const organizationId = sub.metadata?.['organizationId'];
+      if (!organizationId) {
+        logger.warn('customer.subscription.updated missing organizationId metadata');
+        break;
+      }
+      const planCode = sub.metadata?.['planCode'] as PlanCode | undefined;
+      const updates: Parameters<typeof orgDb.updateOrganization>[1] = {
+        status: stripeStatusToOrgStatus(sub.status),
+        stripeSubscriptionId: sub.id,
+      };
+      if (planCode && isPlanCode(planCode)) {
+        updates.planCode = planCode;
+        updates.entitlements = getDefaultEntitlements(planCode);
+      }
+      if (sub.trial_end) {
+        updates.trialEndsAt = new Date(sub.trial_end * 1000);
+      }
+      await orgDb.updateOrganization(organizationId, updates);
+      logger.info('Subscription updated', { organizationId, status: sub.status });
+      break;
+    }
+
+    case 'customer.subscription.deleted': {
+      const sub = event.data.object as Stripe.Subscription;
+      const organizationId = sub.metadata?.['organizationId'];
+      if (!organizationId) break;
+      await orgDb.updateOrganization(organizationId, {
+        planCode: 'community',
+        status: 'canceled',
+        entitlements: getDefaultEntitlements('community'),
+        stripeSubscriptionId: undefined,
+      });
+      logger.info('Subscription cancelled — org reverted to Community', { organizationId });
+      break;
+    }
+
+    case 'invoice.paid': {
+      const invoice = event.data.object as Stripe.Invoice;
+      const customerId = typeof invoice.customer === 'string' ? invoice.customer : null;
+      if (!customerId) break;
+      const orgs = await orgDb.getAllOrganizations();
+      const org = orgs.find(o => o.stripeCustomerId === customerId);
+      if (org && org.status === 'past_due') {
+        await orgDb.updateOrganization(org.id, { status: 'active' });
+        logger.info('Invoice paid — org restored to active', { organizationId: org.id });
+      }
+      break;
+    }
+
+    case 'invoice.payment_failed': {
+      const invoice = event.data.object as Stripe.Invoice;
+      const customerId = typeof invoice.customer === 'string' ? invoice.customer : null;
+      if (!customerId) break;
+      const orgs = await orgDb.getAllOrganizations();
+      const org = orgs.find(o => o.stripeCustomerId === customerId);
+      if (org) {
+        await orgDb.updateOrganization(org.id, { status: 'past_due' });
+        logger.warn('Invoice payment failed — org marked past_due', { organizationId: org.id });
+      }
+      break;
+    }
+
+    default:
+      logger.debug('Unhandled Stripe event', { type: event.type });
+  }
+}
+
+export default router;

--- a/backend/src/services/stripeClient.ts
+++ b/backend/src/services/stripeClient.ts
@@ -1,0 +1,54 @@
+/**
+ * Stripe SDK singleton and plan price ID resolution.
+ *
+ * Price IDs are read from environment variables so the same code works
+ * across test-mode (dev/CI) and live-mode (production) Stripe accounts.
+ *
+ * Required env vars:
+ *   STRIPE_SECRET_KEY          — Stripe secret key (sk_test_... or sk_live_...)
+ *   STRIPE_WEBHOOK_SECRET      — Webhook endpoint signing secret (whsec_...)
+ *   STRIPE_PRICE_BASIC_MONTHLY — price_... for Basic plan, monthly billing
+ *   STRIPE_PRICE_BASIC_ANNUAL  — price_... for Basic plan, annual billing
+ *   STRIPE_PRICE_AI_MONTHLY    — price_... for AI plan, monthly billing
+ *   STRIPE_PRICE_AI_ANNUAL     — price_... for AI plan, annual billing
+ */
+
+import Stripe from 'stripe';
+import { logger } from './logger';
+
+let stripeInstance: Stripe | null = null;
+
+export function getStripeClient(): Stripe {
+  if (stripeInstance) return stripeInstance;
+
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error('STRIPE_SECRET_KEY is not configured');
+  }
+
+  stripeInstance = new Stripe(key);
+  return stripeInstance;
+}
+
+export function isStripeConfigured(): boolean {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    logger.debug('Stripe not configured: STRIPE_SECRET_KEY missing');
+    return false;
+  }
+  return true;
+}
+
+export type BillingInterval = 'monthly' | 'annual';
+
+const PRICE_ENV_VARS: Record<string, string> = {
+  'basic:monthly': 'STRIPE_PRICE_BASIC_MONTHLY',
+  'basic:annual': 'STRIPE_PRICE_BASIC_ANNUAL',
+  'ai:monthly': 'STRIPE_PRICE_AI_MONTHLY',
+  'ai:annual': 'STRIPE_PRICE_AI_ANNUAL',
+};
+
+/** Resolve a Stripe Price ID from the environment. Returns undefined if not configured. */
+export function resolvePriceId(planCode: 'basic' | 'ai', interval: BillingInterval): string | undefined {
+  const envVar = PRICE_ENV_VARS[`${planCode}:${interval}`];
+  return envVar ? process.env[envVar] : undefined;
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -285,6 +285,20 @@ export interface EventAuditLog {
   createdAt: Date;
 }
 
+/**
+ * Audit record for a Stripe webhook event. Written for every event received,
+ * including errors, to provide an idempotency / troubleshooting trail.
+ */
+export interface BillingEvent {
+  id: string;
+  organizationId?: string;
+  stripeEventId: string;
+  eventType: string;
+  payload: string;       // JSON of event.data.object
+  processedAt: Date;
+  error?: string;        // set if processing threw
+}
+
 // ============================================
 // Truck Checks Types
 // ============================================

--- a/frontend/src/components/TrialBanner.css
+++ b/frontend/src/components/TrialBanner.css
@@ -1,0 +1,32 @@
+.trial-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.6rem 1rem;
+  background: #fff3cd;
+  color: #856404;
+  border-bottom: 1px solid #ffc107;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.trial-banner__text {
+  font-weight: 500;
+}
+
+.trial-banner__cta {
+  padding: 0.35rem 0.9rem;
+  background: #e5281b;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.trial-banner__cta:disabled {
+  opacity: 0.6;
+}

--- a/frontend/src/components/TrialBanner.tsx
+++ b/frontend/src/components/TrialBanner.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { api } from '../services/api';
+import './TrialBanner.css';
+
+export function TrialBanner() {
+  const [daysLeft, setDaysLeft] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    api.getBillingStatus()
+      .then(s => {
+        if (s.status === 'trialing' && s.trialEndsAt) {
+          const ms = new Date(s.trialEndsAt).getTime() - Date.now();
+          setDaysLeft(Math.max(0, Math.ceil(ms / 86_400_000)));
+        }
+      })
+      .catch(() => {/* silently ignore — trial banner is non-critical */});
+  }, []);
+
+  if (daysLeft === null) return null;
+
+  async function handleUpgrade() {
+    setLoading(true);
+    try {
+      const { checkoutUrl } = await api.createCheckoutSession('basic', 'monthly');
+      window.location.href = checkoutUrl;
+    } catch {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="trial-banner" role="status">
+      <span className="trial-banner__text">
+        {daysLeft === 0
+          ? 'Your free trial has ended.'
+          : `Free trial: ${daysLeft} day${daysLeft !== 1 ? 's' : ''} remaining`}
+      </span>
+      <button
+        className="trial-banner__cta"
+        onClick={handleUpgrade}
+        disabled={loading}
+      >
+        {loading ? 'Opening…' : 'Add payment method'}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/UpgradePrompt.css
+++ b/frontend/src/components/UpgradePrompt.css
@@ -1,0 +1,57 @@
+.upgrade-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 1.5rem;
+  border: 2px dashed var(--color-border, #ddd);
+  border-radius: 12px;
+  text-align: center;
+  background: var(--color-surface, #fafafa);
+}
+
+.upgrade-prompt__icon {
+  font-size: 2rem;
+}
+
+.upgrade-prompt__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text, #1a1a1a);
+}
+
+.upgrade-prompt__price {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary, #666);
+}
+
+.upgrade-prompt__error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-error, #c0392b);
+}
+
+.upgrade-prompt__cta {
+  padding: 0.75rem 2rem;
+  background: var(--color-primary, #e5281b);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 60px;
+  min-width: 220px;
+  transition: opacity 0.15s;
+}
+
+.upgrade-prompt__cta:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.upgrade-prompt__cta:hover:not(:disabled) {
+  opacity: 0.88;
+}

--- a/frontend/src/components/UpgradePrompt.tsx
+++ b/frontend/src/components/UpgradePrompt.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { api } from '../services/api';
+import './UpgradePrompt.css';
+
+interface Props {
+  feature: string;
+  requiredPlan: 'basic' | 'ai';
+  message?: string;
+}
+
+export function UpgradePrompt({ feature, requiredPlan, message }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const planLabels: Record<string, string> = { basic: 'Basic', ai: 'AI Pro' };
+  const planPrices: Record<string, string> = { basic: 'A$10/mo', ai: 'A$19/mo' };
+
+  async function handleUpgrade() {
+    setLoading(true);
+    setError(null);
+    try {
+      const { checkoutUrl } = await api.createCheckoutSession(requiredPlan, 'monthly');
+      window.location.href = checkoutUrl;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not start checkout');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="upgrade-prompt" role="region" aria-label="Plan upgrade required">
+      <div className="upgrade-prompt__icon" aria-hidden="true">🔒</div>
+      <h3 className="upgrade-prompt__title">
+        {message ?? `${feature} requires the ${planLabels[requiredPlan]} plan`}
+      </h3>
+      <p className="upgrade-prompt__price">
+        From {planPrices[requiredPlan]} per brigade · 14-day free trial
+      </p>
+      {error && <p className="upgrade-prompt__error" role="alert">{error}</p>}
+      <button
+        className="upgrade-prompt__cta"
+        onClick={handleUpgrade}
+        disabled={loading}
+      >
+        {loading ? 'Opening checkout…' : `Upgrade to ${planLabels[requiredPlan]}`}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/organization/OrganizationPage.css
+++ b/frontend/src/features/admin/organization/OrganizationPage.css
@@ -83,6 +83,76 @@
 .org-plan-desc { font-size: 0.85rem; color: var(--text-secondary); flex: 1; }
 .org-plan-current { font-size: 0.85rem; font-weight: 700; color: #008550; }
 
+.org-status { font-weight: 600; }
+.org-status--active { color: #008550; }
+.org-status--trialing { color: #d97706; }
+.org-status--past_due { color: #dc2626; }
+.org-status--canceled { color: var(--text-secondary); }
+
+.org-trial-notice {
+  background: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+}
+
+.org-link-btn {
+  background: none;
+  border: none;
+  color: var(--rfs-core-red);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+  font-size: inherit;
+}
+
+.org-interval-toggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.org-interval-btn {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.org-interval-btn.active {
+  background: var(--rfs-core-red);
+  color: white;
+  border-color: var(--rfs-core-red);
+}
+
+.org-interval-badge {
+  background: #cbdb2a;
+  color: #1a1a1a;
+  border-radius: 10px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.org-plan-downgrade-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.org-billing-actions {
+  margin-top: 1rem;
+}
+
 .org-btn {
   padding: 0.5rem 1rem;
   background: var(--rfs-core-red);
@@ -91,6 +161,12 @@
   border-radius: 6px;
   font-weight: 600;
   cursor: pointer;
+}
+
+.org-btn--secondary {
+  background: transparent;
+  color: var(--rfs-core-red);
+  border: 1px solid var(--rfs-core-red);
 }
 
 .org-btn:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/frontend/src/features/admin/organization/OrganizationPage.tsx
+++ b/frontend/src/features/admin/organization/OrganizationPage.tsx
@@ -2,14 +2,15 @@
  * Organization Management Page (/admin/organization)
  *
  * Owner/admin screen to manage the SaaS tenant:
- * - View plan + status; owners can change plan (entitlements re-derive).
+ * - View plan + status; owners upgrade via Stripe Checkout.
  * - Toggle modules on/off (e.g. hide the sign-in book for a maintenance-only
  *   brigade). AI can only be enabled on the AI plan (clamped server-side).
  * - List org users and invite new admin/viewer accounts.
+ * - Manage subscription via Stripe Customer Portal.
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth, type EntitlementFeature } from '../../../contexts/AuthContext';
 import { api, type PlanDefinition, type OrganizationUser } from '../../../services/api';
 import { PageTransition } from '../../../components/PageTransition';
@@ -26,13 +27,15 @@ export function OrganizationPage() {
   const { organization, user, refreshOrganization } = useAuth();
   const isOwner = user?.role === 'owner';
   const isAdmin = isOwner || user?.role === 'admin';
+  const [searchParams] = useSearchParams();
 
   const [plans, setPlans] = useState<PlanDefinition[]>([]);
   const [users, setUsers] = useState<OrganizationUser[]>([]);
   const [saving, setSaving] = useState(false);
+  const [billingLoading, setBillingLoading] = useState(false);
+  const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly');
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
-  // New-user form
   const [newUsername, setNewUsername] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [newRole, setNewRole] = useState<'admin' | 'viewer'>('viewer');
@@ -54,9 +57,20 @@ export function OrganizationPage() {
     load();
   }, [load]);
 
+  // Show feedback for Stripe redirect outcomes
+  useEffect(() => {
+    const billing = searchParams.get('billing');
+    if (billing === 'success') {
+      flash('success', 'Payment successful! Your plan has been upgraded.');
+      refreshOrganization();
+    } else if (billing === 'cancelled') {
+      flash('error', 'Checkout cancelled — no changes were made.');
+    }
+  }, [searchParams, refreshOrganization]);
+
   function flash(type: 'success' | 'error', text: string) {
     setMessage({ type, text });
-    setTimeout(() => setMessage(null), 4000);
+    setTimeout(() => setMessage(null), 6000);
   }
 
   async function toggleModule(key: EntitlementFeature, value: boolean) {
@@ -73,17 +87,27 @@ export function OrganizationPage() {
     }
   }
 
-  async function changePlan(planCode: PlanDefinition['code']) {
+  async function startCheckout(planCode: 'basic' | 'ai') {
     if (!isOwner) return;
-    setSaving(true);
+    setBillingLoading(true);
     try {
-      await api.updateOrganization({ planCode });
-      await refreshOrganization();
-      flash('success', `Switched to the ${planCode} plan`);
+      const { checkoutUrl } = await api.createCheckoutSession(planCode, billingInterval);
+      window.location.href = checkoutUrl;
     } catch (err) {
-      flash('error', err instanceof Error ? err.message : 'Plan change failed');
-    } finally {
-      setSaving(false);
+      flash('error', err instanceof Error ? err.message : 'Could not start checkout');
+      setBillingLoading(false);
+    }
+  }
+
+  async function openPortal() {
+    if (!isOwner) return;
+    setBillingLoading(true);
+    try {
+      const { portalUrl } = await api.createPortalSession();
+      window.location.href = portalUrl;
+    } catch (err) {
+      flash('error', err instanceof Error ? err.message : 'Could not open billing portal');
+      setBillingLoading(false);
     }
   }
 
@@ -120,6 +144,8 @@ export function OrganizationPage() {
   }
 
   const ent = organization.entitlements;
+  const isPaid = organization.planCode !== 'community';
+  const isTrialing = organization.status === 'trialing';
 
   return (
     <PageTransition variant="fade">
@@ -128,7 +154,9 @@ export function OrganizationPage() {
           <Link to="/" className="back-link">← Back to Home</Link>
           <h1>{organization.name}</h1>
           <p className="org-subtitle">
-            Plan: <strong>{organization.planCode}</strong> · Status: {organization.status}
+            Plan: <strong>{organization.planCode}</strong>
+            {' · '}
+            Status: <span className={`org-status org-status--${organization.status}`}>{organization.status}</span>
           </p>
         </header>
 
@@ -139,32 +167,86 @@ export function OrganizationPage() {
             </div>
           )}
 
+          {isTrialing && (
+            <div className="org-trial-notice" role="status">
+              Your 14-day free trial is active.{' '}
+              {isOwner && (
+                <button className="org-link-btn" onClick={openPortal} disabled={billingLoading}>
+                  Add a payment method
+                </button>
+              )}{' '}
+              to keep access after the trial ends.
+            </div>
+          )}
+
           <section className="org-section">
             <h2>Plan</h2>
+
+            {isOwner && (
+              <div className="org-interval-toggle">
+                <button
+                  className={`org-interval-btn ${billingInterval === 'monthly' ? 'active' : ''}`}
+                  onClick={() => setBillingInterval('monthly')}
+                >
+                  Monthly
+                </button>
+                <button
+                  className={`org-interval-btn ${billingInterval === 'annual' ? 'active' : ''}`}
+                  onClick={() => setBillingInterval('annual')}
+                >
+                  Annual <span className="org-interval-badge">2 months free</span>
+                </button>
+              </div>
+            )}
+
             <div className="org-plans">
-              {plans.map((p) => (
-                <div key={p.code} className={`org-plan ${p.code === organization.planCode ? 'current' : ''}`}>
-                  <div className="org-plan-name">{p.name}</div>
-                  <div className="org-plan-price">{p.priceMonthlyAud === 0 ? 'Free' : `A$${p.priceMonthlyAud}/mo`}</div>
-                  <p className="org-plan-desc">{p.description}</p>
-                  {p.code === organization.planCode ? (
-                    <span className="org-plan-current">Current plan</span>
-                  ) : (
-                    <button className="org-btn" disabled={!isOwner || saving} onClick={() => changePlan(p.code)}>
-                      Switch
-                    </button>
-                  )}
-                </div>
-              ))}
+              {plans.map((p) => {
+                const isCurrent = p.code === organization.planCode;
+                const price = billingInterval === 'annual' && p.priceAnnualAud
+                  ? `A$${p.priceAnnualAud}/yr`
+                  : p.priceMonthlyAud === 0
+                  ? 'Free'
+                  : `A$${p.priceMonthlyAud}/mo`;
+
+                return (
+                  <div key={p.code} className={`org-plan ${isCurrent ? 'current' : ''}`}>
+                    <div className="org-plan-name">{p.name}</div>
+                    <div className="org-plan-price">{price}</div>
+                    <p className="org-plan-desc">{p.description}</p>
+                    {isCurrent ? (
+                      <span className="org-plan-current">Current plan</span>
+                    ) : p.code === 'community' ? (
+                      <span className="org-plan-downgrade-hint">Manage via billing portal</span>
+                    ) : (
+                      <button
+                        className="org-btn"
+                        disabled={!isOwner || billingLoading}
+                        onClick={() => startCheckout(p.code as 'basic' | 'ai')}
+                      >
+                        {billingLoading ? 'Opening…' : `Upgrade to ${p.name}`}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
             </div>
+
+            {isPaid && isOwner && (
+              <div className="org-billing-actions">
+                <button className="org-btn org-btn--secondary" onClick={openPortal} disabled={billingLoading}>
+                  Manage billing & invoices
+                </button>
+              </div>
+            )}
+
             {!isOwner && <p className="org-hint">Only the owner can change the plan.</p>}
           </section>
 
           <section className="org-section">
             <h2>Modules</h2>
             <p className="org-hint">
-              Turn modules on or off for your brigade — e.g. hide the sign-in book on a maintenance-only
-              deployment. The AI agent is only available on the AI plan.
+              Turn modules on or off for your brigade — e.g. hide the sign-in book on a
+              maintenance-only deployment. The AI agent is only available on the AI plan.
             </p>
             <ul className="org-modules">
               {MODULES.map((m) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1271,12 +1271,51 @@ class ApiService {
     }
     return response.json();
   }
+
+  // ============================================
+  // Billing (Stripe)
+  // ============================================
+
+  async createCheckoutSession(planCode: 'basic' | 'ai', billingInterval: 'monthly' | 'annual' = 'monthly'): Promise<{ checkoutUrl: string }> {
+    const response = await fetch(`${API_BASE_URL}/billing/checkout`, {
+      method: 'POST',
+      headers: this.getHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ planCode, billingInterval }),
+    });
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to create checkout session');
+    }
+    return response.json();
+  }
+
+  async createPortalSession(): Promise<{ portalUrl: string }> {
+    const response = await fetch(`${API_BASE_URL}/billing/portal`, {
+      method: 'POST',
+      headers: this.getHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({}),
+    });
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to create portal session');
+    }
+    return response.json();
+  }
+
+  async getBillingStatus(): Promise<BillingStatus> {
+    const response = await fetch(`${API_BASE_URL}/billing/status`, {
+      headers: this.getHeaders(),
+    });
+    if (!response.ok) throw new Error('Failed to fetch billing status');
+    return response.json();
+  }
 }
 
 export interface PlanDefinition {
   code: 'community' | 'basic' | 'ai';
   name: string;
   priceMonthlyAud: number;
+  priceAnnualAud: number;
   description: string;
 }
 
@@ -1287,6 +1326,14 @@ export interface OrganizationUser {
   isActive: boolean;
   lastLoginAt?: string;
   createdAt?: string;
+}
+
+export interface BillingStatus {
+  planCode: 'community' | 'basic' | 'ai';
+  status: 'trialing' | 'active' | 'past_due' | 'canceled';
+  trialEndsAt: string | null;
+  hasPaymentMethod: boolean;
+  stripeConfigured: boolean;
 }
 
 export const api = new ApiService();


### PR DESCRIPTION
## Summary

Wires Stripe billing into the existing Organization + Entitlements model. Closes #553.

### Backend
- **`stripe` SDK** installed; `stripeClient.ts` singleton with env-var price ID resolution
- **`POST /api/billing/checkout`** — creates Stripe Checkout session with 14-day trial; creates/reuses Stripe Customer per org (owner-only)
- **`POST /api/billing/portal`** — Stripe Customer Portal for managing/cancelling subscription (owner-only)
- **`GET /api/billing/status`** — current billing state for the authenticated org
- **`POST /api/billing/webhook`** — signature-verified handler for:
  - `checkout.session.completed` → flip org to trialing, set plan + entitlements
  - `customer.subscription.updated` → sync plan, status, trialEndsAt
  - `customer.subscription.deleted` → revert to Community feature set
  - `invoice.paid` / `invoice.payment_failed` → sync active/past_due status
  - Every event logged as a `BillingEvent` audit row
- Raw body parser registered for `/api/billing/webhook` **before** `express.json()` so Stripe signature verification works correctly
- `BillingEvent` type added to `types/index.ts`
- `plans.ts` updated: separate monthly/annual price env vars; plan descriptions reframed as brigade-centric (not station-count centric); Basic/AI get generous station limits (20) since features — not station count — are the differentiator

### Stripe test-mode catalog (created during implementation)
| Resource | ID |
|---|---|
| Station Manager Basic product | `prod_UjnNizNQc6FiFO` |
| Station Manager AI Pro product | `prod_UjnObDh06HaLRo` |
| Basic Monthly AUD $10 | `price_1TkJo2JICayKeHpbAbgR8Soq` |
| Basic Annual AUD $100 | `price_1TkJo5JICayKeHpbuJrTuJaC` |
| AI Pro Monthly AUD $19 | `price_1TkJo8JICayKeHpbo9XUbCCI` |
| AI Pro Annual AUD $190 | `price_1TkJoCJICayKeHpbTZnCiCeE` |

### Frontend
- `api.ts`: `createCheckoutSession()`, `createPortalSession()`, `getBillingStatus()`
- **`UpgradePrompt`** component — shown on plan-gated features with one-click checkout
- **`TrialBanner`** component — trial countdown with "Add payment method" CTA
- **`OrganizationPage`** updated:
  - Monthly/Annual billing interval toggle (annual = 2 months free)
  - Stripe Checkout buttons (replaces direct plan-switch for paid plans)
  - "Manage billing & invoices" portal button (shown when on a paid plan)
  - Trial notice with portal shortcut
  - `billing=success` / `billing=cancelled` query-param feedback on Stripe redirect return

## Required env vars (add to Azure App Service + local `.env`)
```
STRIPE_SECRET_KEY=sk_test_...
STRIPE_WEBHOOK_SECRET=whsec_...
STRIPE_PRICE_BASIC_MONTHLY=price_1TkJo2JICayKeHpbAbgR8Soq
STRIPE_PRICE_BASIC_ANNUAL=price_1TkJo5JICayKeHpbuJrTuJaC
STRIPE_PRICE_AI_MONTHLY=price_1TkJo8JICayKeHpbo9XUbCCI
STRIPE_PRICE_AI_ANNUAL=price_1TkJoCJICayKeHpbTZnCiCeE
```

For local webhook testing: `stripe listen --forward-to localhost:3000/api/billing/webhook`

## Test plan
- [ ] Backend typecheck passes (`npx tsc --noEmit`)
- [ ] All 545 backend tests pass
- [ ] All 442 frontend tests pass
- [ ] Sign up → `/admin/organization` → click Upgrade → Stripe Checkout opens (test card `4242 4242 4242 4242`)
- [ ] After successful checkout, org status flips to `trialing`, entitlements update
- [ ] "Manage billing & invoices" opens Stripe Customer Portal
- [ ] Cancel subscription → org reverts to Community entitlements
- [ ] Trial banner appears during trialing status
- [ ] UpgradePrompt shown on gated feature pages

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S)_