### PR TITLE
docs: collapse all plans into one MASTER_PLAN + start type standardisation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,8 +20,8 @@ This repository follows strict documentation discipline to ensure consistency, m
 - **Location**: `/docs/MASTER_PLAN.md`
 - **Purpose**: Single source of truth for ALL planning, roadmap, phases, enhancement tracking, and strategic intent
 - **Requirements**:
-  - ALL feature planning, enhancement backlog, technical debt, and future roadmap MUST be documented here
-  - NO duplicate planning documents allowed
+  - ALL feature planning, enhancement backlog, technical debt, and future roadmap MUST be documented here — across **all three apps** (`backend/`, `frontend/`, `aar-studio/`) and the wider Bushie Tools suite
+  - **NO duplicate planning documents allowed — there is exactly one plan.** Do NOT create new planning, roadmap, design-spike, or "future work" docs. When capturing future work or a design decision, EDIT `MASTER_PLAN.md`. The former separate plans (`CONSOLIDATION_REVIEW`, `SUITE_INTEGRATION_PLAN`, `SAAS_COMMERCIALIZATION_DESIGN`, `AI_MAINTENANCE_AGENT_DESIGN`, `AAR_STUDIO_PLAN`) were folded into MASTER_PLAN's "Consolidation & Standardisation Roadmap" and moved to `docs/archive/` for historical design reference only
   - All major documentation files MUST reference the master plan
   - All PRs that affect project direction MUST update the master plan
   - Version-controlled and living document (updated continuously)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ view reports. Changes sync live across kiosks/tablets/phones via WebSockets.
 - **Status**: v1.1 in production — sign-in, truck check, and reports all shipped.
   Features are gated per-organization by SaaS **entitlements** (see "SaaS tenancy
   & entitlements"). AAR Studio is live at `/aar`. Stripe billing is designed
-  (`docs/SAAS_COMMERCIALIZATION_DESIGN.md`) but **not yet wired**.
+  (roadmap in `docs/MASTER_PLAN.md`; design in
+  `docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md`) but **not yet wired**.
 - **DB**: Azure Table Storage in prod; in-memory store for local dev/tests.
   Selected at runtime by `dbFactory` (see below).
 - **Deploy**: GitHub Actions → Azure **Linux** App Service (`bungrfs-linux`). The
@@ -139,7 +140,9 @@ Organizations are the billing tenant; features are gated per-org. Default-**off*
   for admin/role — never mix the two.
 - **Not yet built:** Stripe checkout/portal/webhooks, usage metering
   (`UsageRecord`), and gating on a few routes (`export`, station/device limits).
-  See `docs/SAAS_COMMERCIALIZATION_DESIGN.md` and `docs/CONSOLIDATION_REVIEW.md`.
+  See the Consolidation & Standardisation Roadmap in `docs/MASTER_PLAN.md`
+  (commercialisation track C1–C4); detailed design in
+  `docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md`.
 
 ## Backend file index (`backend/src/`)
 
@@ -205,8 +208,11 @@ Organizations are the billing tenant; features are gated per-org. Default-**off*
 
 ## Docs you should consult (don't re-derive)
 
-- `docs/MASTER_PLAN.md` — **single source of truth** for roadmap, priorities,
-  technical debt. Update it when changing project direction.
+- `docs/MASTER_PLAN.md` — **the single plan.** Source of truth for roadmap,
+  priorities, technical debt, *and* all cross-app/commercialisation/AI/suite work
+  (see its "Consolidation & Standardisation Roadmap"). **There is no other plan.**
+  When capturing future work or a design decision, edit this file — never create a
+  new planning/design/roadmap doc. Update it when changing project direction.
 - `docs/AS_BUILT.md` — current architecture/implementation of record.
 - `docs/api_register.json` + `docs/function_register.json` — machine-readable
   endpoint/function registries (Draft-7). Update when APIs/signatures change;
@@ -214,13 +220,17 @@ Organizations are the billing tenant; features are gated per-org. Default-**off*
 - `docs/API_DOCUMENTATION.md`, `docs/openapi.yaml` — REST/WS reference.
 - `docs/GETTING_STARTED.md`, `docs/FEATURE_DEVELOPMENT_GUIDE.md` — dev guides.
 - `docs/AZURE_DEPLOYMENT.md`, `docs/ci_pipeline.md` — deploy/CI.
-- `docs/CONSOLIDATION_REVIEW.md` — cross-app coherence roadmap (design-system
-  unification, server-side AI gateway, AAR identity/persistence, shared types).
-- `docs/SAAS_COMMERCIALIZATION_DESIGN.md` — plans/pricing, Stripe billing design,
-  usage metering. `docs/AI_MAINTENANCE_AGENT_DESIGN.md` — server-side AI agent.
+- `docs/SUITE_TOKEN_VALIDATION.md` — current contract for sibling apps validating
+  the SM JWT (reference, not a plan).
+- **Archived design spikes** (`docs/archive/`) — historical detail only, *not* live
+  plans; their forward work is in MASTER_PLAN's roadmap: `CONSOLIDATION_REVIEW.md`
+  (cross-app coherence, AI gateway), `SAAS_COMMERCIALIZATION_DESIGN.md`
+  (pricing/Stripe/tenancy schema), `AI_MAINTENANCE_AGENT_DESIGN.md` (voice/vision
+  agent schema + tool contract), `SUITE_INTEGRATION_PLAN.md` (suite options),
+  `AAR_STUDIO_PLAN.md` (AAR stage history).
 - `.github/copilot-instructions.md` — full conventions (this file is the short form).
-- `docs/archive/` historical; `docs/implementation-notes/` deep dives;
-  `docs/current_state/` dated snapshots + UI screenshots.
+- `docs/implementation-notes/` deep dives; `docs/current_state/` dated snapshots +
+  UI screenshots.
 
 ## Conventions (the ones that bite)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,28 @@ Guidance for Claude Code (and other AI agents) working in this repo. Optimised
 for fast, token-efficient navigation — **read the indexed file you need instead
 of grepping the whole tree.**
 
+## ⛔ THE ONE-PLAN RULE (non-negotiable)
+
+**There is exactly one plan: `docs/MASTER_PLAN.md`. Do not create any other.**
+
+- **NEVER** create a new planning, roadmap, design-spike, "future work", proposal,
+  strategy, or `*_PLAN.md` / `*_DESIGN.md` / `*_ROADMAP.md` document — not in
+  `docs/`, not in an app folder, not anywhere. This includes splitting a plan
+  "just for this feature" or dropping a design doc next to code.
+- To capture future work, a design decision, a phase, or a change of direction:
+  **edit `docs/MASTER_PLAN.md`** (its "Consolidation & Standardisation Roadmap" is
+  the home for cross-app / SaaS / AI / suite work). That is the single source of
+  truth for *all three apps* (`backend/`, `frontend/`, `aar-studio/`) and the suite.
+- The former separate plans were folded in and moved to `docs/archive/` (banners
+  point back here). They are historical design **reference only — not live plans**;
+  never resurrect one as the place to plan.
+- If a planning doc somehow reappears, treat it as a defect: fold its content into
+  `MASTER_PLAN.md` and archive it. Don't add to it.
+
+(`AS_BUILT.md`, `API_DOCUMENTATION.md`, registries, and the `archive/` /
+`implementation-notes/` reference docs describe what *is* built — they are not
+plans and are unaffected by this rule.)
+
 ## What this is
 
 RFS Station Manager — a real-time digital sign-in system for NSW Rural Fire

--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@ Reference:
 - **[docs/AZURE_DEPLOYMENT.md](docs/AZURE_DEPLOYMENT.md)** — production deployment
 - **[docs/AUTHENTICATION_CONFIGURATION.md](docs/AUTHENTICATION_CONFIGURATION.md)** — auth & entitlements config
 
-SaaS & suite:
-- **[docs/SAAS_COMMERCIALIZATION_DESIGN.md](docs/SAAS_COMMERCIALIZATION_DESIGN.md)** — plans, pricing, billing model
-- **[docs/SUITE_INTEGRATION_PLAN.md](docs/SUITE_INTEGRATION_PLAN.md)** — multi-app suite strategy
+Planning & SaaS/suite:
+- **[docs/MASTER_PLAN.md](docs/MASTER_PLAN.md)** — the single plan: roadmap, pricing, and the Consolidation & Standardisation Roadmap (cross-app, SaaS, AI, suite). No other planning doc exists.
 - **[docs/SUITE_TOKEN_VALIDATION.md](docs/SUITE_TOKEN_VALIDATION.md)** — sibling-app token/entitlement contract
+- Design history (reference only): [docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md](docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md), [docs/archive/SUITE_INTEGRATION_PLAN.md](docs/archive/SUITE_INTEGRATION_PLAN.md)
 
 Historical material lives in [docs/archive/](docs/archive/); dated snapshots and
 UI screenshots in [docs/current_state/](docs/current_state/); deep dives in
@@ -247,8 +247,8 @@ security section of [docs/AS_BUILT.md](docs/AS_BUILT.md).
 foundation (organizations, plans, entitlements) and Stripe billing are wired in
 test mode. AAR Studio is live at `/aar`. The Bushie Tools suite is at Phase 1
 (shared identity + subscription + app launcher); shared packages (Phase 2) and
-monorepo consolidation (Phase 3) are planned — see
-[docs/SUITE_INTEGRATION_PLAN.md](docs/SUITE_INTEGRATION_PLAN.md).
+monorepo consolidation (Phase 3) are planned — see the Consolidation &
+Standardisation Roadmap in [docs/MASTER_PLAN.md](docs/MASTER_PLAN.md).
 
 ## Contributing
 

--- a/aar-studio/README.md
+++ b/aar-studio/README.md
@@ -14,8 +14,9 @@ development you can still bring your own Azure resources via the Settings screen
 
 > Status: Stages 1–4 complete — setup, live listen with real-time
 > transcription, transcript paste ingest, AI extraction, live board, review,
-> AI report generation and all exports. Stage 5 polish remains — see
-> [`docs/PLAN.md`](docs/PLAN.md).
+> AI report generation and all exports. Stage 5 polish remains — tracked in the
+> root [`docs/MASTER_PLAN.md`](../docs/MASTER_PLAN.md) (roadmap item P1); stage
+> history archived at [`docs/archive/AAR_STUDIO_PLAN.md`](../docs/archive/AAR_STUDIO_PLAN.md).
 
 ## The workflow
 
@@ -128,4 +129,6 @@ You can still run it fully standalone for local development with
 ## Repository layout
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the module map and data
-model, and [`docs/PLAN.md`](docs/PLAN.md) for the staged roadmap.
+model. The staged roadmap is folded into the root
+[`docs/MASTER_PLAN.md`](../docs/MASTER_PLAN.md) (stage history archived at
+[`docs/archive/AAR_STUDIO_PLAN.md`](../docs/archive/AAR_STUDIO_PLAN.md)).

--- a/aar-studio/docs/ARCHITECTURE.md
+++ b/aar-studio/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ aar-studio/
 ├── data/sample-session.json    # Wamboin structure fire example session
 ├── test/                       # node:test suites for js/lib (zero deps)
 ├── package.json                # {"type":"module"} + npm test (node --test)
-└── docs/ (PLAN.md, ARCHITECTURE.md)
+└── docs/ (ARCHITECTURE.md — the forward plan lives in root docs/MASTER_PLAN.md)
 ```
 
 Served by the Station Manager Express backend at `/aar` (see "Security /

--- a/backend/src/constants/plans.ts
+++ b/backend/src/constants/plans.ts
@@ -5,7 +5,8 @@
  * its default Entitlements and display/price metadata. The (future) Stripe
  * Price IDs are configured via env so the catalog stays deployment-agnostic.
  *
- * Pricing rationale lives in docs/SAAS_COMMERCIALIZATION_DESIGN.md.
+ * Pricing rationale lives in docs/MASTER_PLAN.md (Pricing & plans reference);
+ * the full design analysis is docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md.
  */
 
 import type { Entitlements, PlanCode } from '../types';

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -20,7 +20,8 @@
  *  - Requests with no org context (anonymous AAR, kiosk/demo, back-compat) pass
  *    the gate, consistent with the rest of the entitlement system; usage is only
  *    recorded when an org is known. Full AAR identity is tracked separately
- *    (docs/CONSOLIDATION_REVIEW.md).
+ *    (docs/MASTER_PLAN.md roadmap item A2; design in
+ *    docs/archive/CONSOLIDATION_REVIEW.md).
  */
 
 import { Router, Request, Response } from 'express';

--- a/backend/src/services/meteredUsageReporter.ts
+++ b/backend/src/services/meteredUsageReporter.ts
@@ -6,7 +6,7 @@
  *
  * This is intentionally conservative: it only sends usage when BOTH a Stripe
  * key and a metered price/meter are configured. Until the metered price is wired
- * up (see docs/SAAS_COMMERCIALIZATION_DESIGN.md §7b), it is a safe no-op that
+ * up (see docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md §7b), it is a safe no-op that
  * leaves rows unreported so nothing is lost.
  */
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,14 +1,16 @@
 # RFS Station Manager - Master Plan
 
-**Document Version:** 2.1  
-**Last Updated:** June 20, 2026  
-**Status:** Living Document  
+**Document Version:** 3.0  
+**Last Updated:** June 21, 2026  
+**Status:** Living Document — **the single plan** (all other planning docs folded in here)  
 **Purpose:** Single source of truth for planning, roadmap, architecture guidance, and issue tracking
 
 ---
 
 ### Single Source of Truth
-This document is the **SINGLE SOURCE OF TRUTH** for all planning, roadmap, architecture guidance, and future work tracking for the RFS Station Manager project. All planning must be consolidated here - no duplicate planning documents are permitted.
+This document is the **SINGLE SOURCE OF TRUTH** for all planning, roadmap, architecture guidance, and future work tracking for the RFS Station Manager project — across **all three apps** (`backend/`, `frontend/`, `aar-studio/`) and the wider Bushie Tools suite.
+
+**There is exactly one plan, and this is it.** No other planning, roadmap, design-spike, or "future work" document may exist as a live doc. The previously separate plans — `CONSOLIDATION_REVIEW.md`, `SUITE_INTEGRATION_PLAN.md`, `SAAS_COMMERCIALIZATION_DESIGN.md`, `AI_MAINTENANCE_AGENT_DESIGN.md`, and `aar-studio/docs/PLAN.md` — have been **collapsed into this file** (see "Consolidation & Standardisation Roadmap" below) and moved to `docs/archive/` for historical design reference only. When you need to capture future work, a design decision, or a change of direction, **edit this document** — do not create a new plan. Detailed, still-useful design content (schemas, pricing rationale, tool contracts) lives in the archived spikes and may be cited as reference, but the authoritative status, priority, and sequencing live here.
 
 ### Documentation Organization Policy
 
@@ -53,7 +55,14 @@ Only the following types of documents are allowed in the root `/docs/` directory
 - **API Documentation**: `docs/API_DOCUMENTATION.md` - Human-readable API reference
 - **Feature Guides**: `docs/FEATURE_DEVELOPMENT_GUIDE.md`, `docs/GETTING_STARTED.md`
 - **UI Review**: `docs/current_state/UI_REVIEW_20260207.md` - Comprehensive UI/UX review with iPad screenshots
-- **Suite / Multi-App Strategy**: `docs/SUITE_INTEGRATION_PLAN.md` - Assessment + options for delivering Station Manager, AAR Studio, Fire Break Calculator and Fire Santa Run as one product suite (the **"Bushie Tools"** brand — shared identity, subscription, brand)
+- **Token-validation contract**: `docs/SUITE_TOKEN_VALIDATION.md` - How sibling Bushie Tools apps validate the Station Manager JWT (current contract, reference)
+
+**Archived design spikes** (historical reference — *not* live plans; their forward work is tracked in this file's roadmap below):
+- `docs/archive/CONSOLIDATION_REVIEW.md` - cross-app coherence analysis & AI-gateway direction
+- `docs/archive/SUITE_INTEGRATION_PLAN.md` - Bushie Tools suite federation/monorepo options
+- `docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md` - pricing analysis, Stripe surface, tenancy schema deltas
+- `docs/archive/AI_MAINTENANCE_AGENT_DESIGN.md` - voice/vision truck-maintenance agent schema & tool contract
+- `docs/archive/AAR_STUDIO_PLAN.md` - AAR Studio stage plan (architecture of record stays in `aar-studio/docs/ARCHITECTURE.md`)
 
 ### Companion app: AAR Studio (June 2026)
 
@@ -67,9 +76,12 @@ Studio**. The backend applies the extra CSP / `Permissions-Policy` it needs,
 scoped to `/aar` (see `backend/src/index.ts`); the bundle is located via
 `AAR_STUDIO_PATH` (default `../aar-studio`) and must be included in the deploy
 package. `aar-studio.yml` runs the unit tests only; `ci-cd.yml` handles
-deployment. Its plan and architecture live in `aar-studio/docs/PLAN.md` and
-`aar-studio/docs/ARCHITECTURE.md`; the registries and AS_BUILT in this
-directory intentionally do not cover its internals.
+deployment. Its **architecture of record** lives in
+`aar-studio/docs/ARCHITECTURE.md`; its **forward plan** is no longer separate —
+it is folded into the Consolidation & Standardisation Roadmap below (the old
+`aar-studio/docs/PLAN.md` is archived as `docs/archive/AAR_STUDIO_PLAN.md`). The
+registries and AS_BUILT in this directory intentionally do not cover its
+internals.
 
 ---
 
@@ -133,11 +145,14 @@ The Station Manager v1.0 MVP focuses exclusively on **core sign-in functionality
 - Achievement system
 - Additional enhancements based on client feedback
 
-### Commercialization & coherence roadmap (mid-2026, planning)
+## Consolidation & Standardisation Roadmap
 
-Forward plan captured in increments. Cross-app detail in `docs/CONSOLIDATION_REVIEW.md`,
-billing detail in `docs/SAAS_COMMERCIALIZATION_DESIGN.md`, suite integration in
-`docs/SUITE_INTEGRATION_PLAN.md`. Recommended order — each item links to its GitHub issue:
+*This is the consolidated roadmap for commercialisation **and** cross-app coherence.
+It supersedes and folds together the five archived design spikes
+(`CONSOLIDATION_REVIEW`, `SUITE_INTEGRATION_PLAN`, `SAAS_COMMERCIALIZATION_DESIGN`,
+`AI_MAINTENANCE_AGENT_DESIGN`, `AAR_STUDIO_PLAN`). Items reference their GitHub
+issue where one exists; detailed schemas/contracts cited as "(archive: …)" live in
+the corresponding archived spike for reference only.*
 
 > **Guiding ethos — "for the average bushie."** Design for the older, less
 > tech-savvy firefighter as much as the young guns: plain language (no jargon),
@@ -145,50 +160,138 @@ billing detail in `docs/SAAS_COMMERCIALIZATION_DESIGN.md`, suite integration in
 > targets, and "just talk / just tap" flows. If a bushie can't use it cold,
 > it's not done. Apply this lens to every UI/UX point below.
 
-- **[#549] Rebrand to "Bushie Tools"** — adopt *Bushie Tools* as the product-family /
-  suite name (colloquial for bush firefighters), framing Station Manager, AAR
-  Studio, Fire Break Calculator and Fire Santa Run as approachable tools that put
-  advanced capability in ordinary members' hands. This is the customer-facing name
-  for the multi-app suite analysed in `docs/SUITE_INTEGRATION_PLAN.md` — the
-  rebrand and that suite-integration work are the same product story (one brand,
-  one login, one subscription). Naming/branding sweep across landing, app-picker,
-  AAR Studio, and docs; fold into the design-system work below so brand and tokens
-  land together.
-- **[#550] Visual consistency (design-system unification)** — extract one canonical
-  RFS token set (palette `#e5281B`/`#cbdb2a`, Public Sans, spacing, ≥60px touch
-  targets) into a shared CSS file used by both the React SPA and AAR Studio;
-  realign AAR's divergent brand/fonts and fix its sub-60px controls. Low-risk,
-  do first / in parallel with #549.
-- **[#551] Collaborative session notes (AAR Studio)** — recording stays the centre
-  of gravity, but let a room contribute alongside it: timestamped text notes added
-  live by other participants on their own devices, aligned to the recorded
-  discussion timeline. A shared session (URL/code), a lightweight note-taker
-  role, and multi-contributor input (voice + text) so a whole room can feed one
-  review. Notes merge into findings extraction like transcript segments.
-- **[#544 — shipped] AAR Studio UX redesign for non-technical users** — friendly
-  landing, one-tap "quick kick-off" recording, automatic phase + finding-category
-  inference, metadata from the discussion, jargon removed. ✅ Merged Jun 2026.
-- **[#552] Entitlement-enforcement hardening (prerequisite for paid tiers)** — close
-  the gating leaks so every feature/route is controlled by plan: gate `/api/export`,
-  enforce `maxStations`/`maxDevices` limits on creation, audit each route's
-  `requireFeature`/`FeatureRoute` pairing. Must land before billing.
-- **[#553] Stripe billing (SaaS Phase B)** — `stripe` SDK + price env mapping;
-  checkout session endpoint; signature-verified webhook that syncs org `status` +
-  `entitlements` from subscription events; customer-portal link; `BillingEvent`
-  audit; trial flow. Turns the existing plan model into real subscriptions.
-- **[#554] Marketing landing for unauthenticated visitors** — a logged-out front
-  door (what it is, plan/pricing tiers, sign-up CTA → checkout); the current public
-  app-picker becomes the post-login home. See `docs/SAAS_COMMERCIALIZATION_DESIGN.md`
-  §7 for the full pricing model discussion including tier options, per-brigade vs
-  per-user pricing, and AI metering.
-- **[#555] AI tier features** — server-side AI gateway (metered, capability-routed
-  text/voice/image, provider adapters); `UsageRecord` metering; migrate AAR Studio's
-  browser-direct AI behind the gateway. See `CONSOLIDATION_REVIEW.md` and
-  `AI_MAINTENANCE_AGENT_DESIGN.md`.
-- **[#557] Bushie Tools suite — Phase 2: shared packages** — extract `@rfs/ui`,
-  `@rfs/types`, `@rfs/auth-sdk`, `@rfs/data` for adoption by all four apps.
-- **[#558] Bushie Tools suite — Phase 3: monorepo consolidation** — single
-  deployment (pending architecture decisions: auth, real-time transport, CI/CD).
+### The standardisation problem (why this roadmap exists)
+
+The repo ships as **one** Azure App Service deployment but is **three** codebases
+that have diverged in stack, brand, AI architecture, identity, and data:
+
+| | Main backend | Main frontend | AAR Studio |
+|---|---|---|---|
+| Stack | Express 5 + Socket.io + TS | React 19 + Vite + TS | Vanilla HTML/CSS/ES modules, no build |
+| Served at | `/api/*` | `/` (SPA) | `/aar` (static mount) |
+| Auth | JWT/admin + entitlements | `ProtectedRoute` / feature gates | inherits SM JWT (same origin) |
+| Persistence | Table Storage / in-memory (factories) | — | browser `localStorage` |
+| Types | `backend/src/types` (`Date`) | `frontend/src/types` (`string`) — **duplicated, drifting** | `js/model.js` (disjoint) |
+
+They now **deploy** as one app; the work below makes them **coherent** as one
+app. The wider Bushie Tools suite (Fire Break Calculator, Fire Santa Run) adds two
+more separate repos/stacks to converge.
+
+### Shipped (recorded here as done; the archived spikes still framed these "future")
+
+- **Design-system unification + "Bushie Tools" rebrand** (#549 + #550) — canonical
+  `aar-studio/css/rfs-tokens.css`, SPA mirrors it; brand red `#c8102e`, Public Sans,
+  tokens app-wide. *Open caveat:* AAR touch targets are 60px (primary) / 44px
+  (inline/nav) — owner to confirm strict-60 or accept (item S1 below).
+- **Server-side AI gateway** (#555) — `backend/src/services/aiGateway.ts`,
+  `/api/ai/{chat,report,speech/token,usage}`, `UsageRecord` twins, session metering.
+  AAR Studio migrated off browser-direct Azure. *Open within it:* Anthropic adapter
+  is a stub; image/vision + streaming-voice WS not built (items A1, A4 below).
+- **Suite Phase 1 — shared identity/subscription federation** (#556) — SM JWT as the
+  suite IdP, `GET /api/auth/entitlements`, per-app flags, app-launcher landing.
+- **SaaS Phase A — tenant model** (Jun 8) — `Organization`, plan catalog, signup,
+  `requireFeature` gating, `ENABLE_ENTITLEMENTS`.
+- **AAR collaborative session notes — core** (#551). **Marketing/pricing landing +
+  checkout deep-link** (#554). **Free-tier caps** (10 members / 1 vehicle) (#574).
+
+### Now — standardisation track (cross-app coherence; do these next)
+
+Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision first.
+
+- **T1 — Shared domain types** ⬜ *(start here; lowest-risk standardisation win)*.
+  `Station`/`Member` (and the truck-check types) are defined twice and have drifted
+  (`Date` vs `string`; the frontend `Activity` lost `category`/`tagColor`/`stationId`;
+  `Appliance`/`CheckIn` lost `stationId`). **Increment 1 (no build changes):** re-sync
+  `frontend/src/types` to the backend shape and document backend `types/index.ts` as
+  the contract of record. **Increment 2:** extract a real shared module — this is the
+  same work as the suite's `@rfs/types` (#557) and wants the npm-workspace foundation
+  (T6); resolve the `Date`-vs-`string` split with a date-generic (`Member<TDate = string>`)
+  so one definition serves both. (archive: CONSOLIDATION_REVIEW #4)
+- **S1 — Finish the design-system pass** ⬜ — confirm/raise AAR inline controls to
+  strict-60px if the owner wants it; add `prefers-reduced-motion` guards (e.g.
+  `.live__dot`); share the RFS-branded HTML/print **report template** that the three
+  export paths reinvent (piggyback on the tokens). (archive: CONSOLIDATION_REVIEW #2/#5)
+- **A2 — AAR identity & server-side persistence** ⬜ (effort L) — pass the logged-in
+  token into AAR; add `/api/aar-sessions` CRUD on the storage factories (`AARSessions`
+  table, partition by org/brigade); replace AAR's free-text setup with a station/member
+  picker from the roster; **shrink the `/aar` CSP** to gateway-only `connect-src` (drop
+  `*.openai.azure.com` / `*.cognitiveservices.azure.com` / `wss://*.stt.speech.microsoft.com`)
+  and update `aar-studio/docs/ARCHITECTURE.md`. Depends on the shipped gateway + SaaS.
+  (archive: CONSOLIDATION_REVIEW #3)
+
+### Commercialisation track (SaaS billing & metering)
+
+- **C1 — Entitlement-enforcement hardening** 🟡 (#552) — finish gating `/api/export`
+  behind `reportsEnabled`, enforce `maxStations`/`maxDevices` on creation, audit every
+  `requireFeature`/`FeatureRoute` pairing. *Prerequisite for billing.*
+- **C2 — Stripe billing (SaaS Phase B)** ⬜ (#553) — `stripe` SDK + price-ID env mapping;
+  checkout endpoint; signature-verified webhook syncing org `status`+`entitlements`;
+  `BillingEvent` audit; Customer Portal; trial flow. *Live billing is not wired —
+  entitlements are admin-set; `meteredUsageReporter.ts` is a no-op until a meter exists.*
+- **C3 — AI metering completion (Phase D)** 🟡 — session metering + allowance shipped;
+  build top-up packs / overage purchase. **C4 — Device accounts + member activation
+  (Phase C)** ⬜ — formalise `BrigadeAccessToken` → first-class `Device`; member
+  email-invite activation (`authStatus`). (archive: SAAS_COMMERCIALIZATION_DESIGN)
+
+### AI maintenance agent track (truck check by voice/vision)
+
+- **A1 — Phase 1: truck model** ⬜ — new `ApplianceZone` / `ApplianceEquipment` entities
+  (both DB twins + types + factories), `Appliance`/`ChecklistItem` extensions, admin
+  authoring UI, canonical per-`vehicleType` vocabularies. Ships standalone value (no AI).
+- **A3 — Phase 2: voice agent (cloud)** ⬜ — PWA voice mode → agent tool-use loop
+  (`get_appliance_context`/`record_result`/`flag_issue`/`next_unchecked_in_zone`/
+  `complete_run`) → `CheckRun` + `AgentSession`/`AgentTurn` transcript; read-back/confirm;
+  `needsReview`; Blob containers `agent-audio`/`agent-frames`. Needs the streaming-voice
+  WS contract (D3). **A4 — Phase 3/4: offline + vision** ⬜ — on-device speech; camera
+  frames + visual diff vs `referencePhotoUrl`; image capability in the gateway.
+  (archive: AI_MAINTENANCE_AGENT_DESIGN — schemas & tool contract verbatim)
+
+### Suite convergence track (Bushie Tools Phases 2–3)
+
+- **T6 — Phase 2: shared packages** ⬜ (#557) — establish an npm/pnpm workspace and
+  extract `@rfs/ui`, `@rfs/types` (= T1 increment 2), `@rfs/auth-sdk`, `@rfs/data`;
+  sibling repos consume `/api/auth/entitlements`; SSO redirect for cross-origin apps.
+- **T7 — Phase 3: monorepo consolidation** ⬜ (#558) — Turborepo workspace; Fire Break
+  Calculator → embedded feature route; Fire Santa Run → seasonal peer app; converge the
+  backends (port Hono/Azure Functions → Express); single App Service; 3 CI pipelines → 1
+  (preserving SM's ordered gates). (archive: SUITE_INTEGRATION_PLAN — options A/B/C)
+
+### AAR Studio polish (Stage 5)
+
+- **P1** ⬜ — dedupe-threshold tuning + merge-suggestion UI; accessibility pass
+  (keyboard-only board, ARIA live regions for Present mode); print-stylesheet
+  refinements; per-unit finding attribution; optional `?demo` deep link.
+  (archive: AAR_STUDIO_PLAN Stage 5)
+
+### Pricing & plans (reference)
+
+The live plan catalog is code (`backend/src/constants/plans.ts`); this is the
+intended commercial shape (full rationale: archive SAAS_COMMERCIALIZATION_DESIGN §7):
+
+| Tier | Price (AUD) | Members | Vehicles | Includes |
+|---|---|---|---|---|
+| **Community** (free) | $0 | up to 10 | 1 | Manual sign-in + 1 vehicle check, single station |
+| **Basic** | $10/mo · $100/yr | unlimited | unlimited | Full manual suite + reports & CSV export, multiple stations |
+| **AI Pro** | $19/mo · $190/yr | unlimited | unlimited | Basic + AI AAR Studio (~25 sessions/mo), voice agent |
+| **Bushie Suite** *(planned)* | $29/mo · $290/yr | unlimited | unlimited | AI Pro + all Bushie Tools apps (once T6/T7 ship) |
+
+Stripe AU ≈ 1.75% + $0.30; AI ≈ $0.60/AAR session; annual = 2 months free. `maxDevices`
+is retained in the model but **unused/unenforced** (devices dropped from pricing in #574).
+
+### Open decisions (resolve before locking the gated work) 🔵
+
+- **D1 — Pricing details:** pricing unit (flat per-station recommended); confirm tier
+  names/prices; AI metering unit (session for AAR vs audio-minute for voice agent);
+  top-up pack sizes; trial length (14 vs 30 days; AI in trial?); grant/PO Invoicing;
+  per-org vs per-station billing for district orgs; AAR-in-Basic; Fire Break
+  free-on-Community vs suite-only; Santa Run seasonal billing.
+- **D2 — Suite auth standard:** keep SM JWT (current, per #556) vs adopt Entra External
+  ID for authN — Entra adds an existing-user migration runbook. Currently: **keep SM JWT.**
+- **D3 — AI gateway specifics:** initial provider per capability + per-org override;
+  `UsageRecord`↔Stripe-meter mapping; the streaming-voice WebSocket contract (blocks A3).
+- **D4 — Unified real-time transport:** Socket.io vs Azure Web PubSub for a converged
+  backend (current lean: defer SignalR; adopt Web PubSub for Socket.IO when scale needs
+  a backplane). **D5 — Deploy size/time:** shrink the package, target deploy < 10 min.
 
 ### June 2026 Stabilization
 - 2026-06-20: **Bushie Tools suite — Phase 1: shared identity & subscription (#556).** Stood up Station Manager's entitlements as the canonical suite licensing layer (Option A / federation — apps stay in their own repos and validate the same SM JWT). **Per-app flags:** `Entitlements` (and the frontend mirror) gained `aarStudioEnabled` (true on AI Pro), `santaRunEnabled` and `fireBreakEnabled` (reserved — no plan grants them yet); `constants/plans.ts` sets them per tier and `clampEntitlements()` enforces the ceiling. **Cross-app endpoint:** new `GET /api/auth/entitlements` — a lightweight JWT-verified probe returning `{ entitlements, planCode, status }` (null org → null payload) so sibling apps gate features without the larger `/auth/me` shape; same-origin in Phase 1, cross-origin covered by the existing `FRONTEND_URLS`/`allowedOriginsList` CORS seam. **Auth decision:** kept SM JWT as the suite IdP rather than Entra External ID — kiosk/station iPads authenticate with brigade access tokens (not user accounts), a scenario the JWT/brigade-token model already supports; recorded in the new protocol doc. **App-launcher:** the logged-in `LandingPage` now doubles as the suite launcher — the AAR Studio card locks to an "Upgrade to AI Pro" placeholder below the AI plan, and new sibling-app cards (Fire Santa Run — seasonal-badged; Fire Break Calculator) render from a `config/suiteApps.ts` catalog, gated by their flags and linked out via build-time `VITE_SANTA_RUN_URL`/`VITE_FIREBREAK_URL` (unlocked when no org context, for back-compat). New `docs/SUITE_TOKEN_VALIDATION.md` documents the validation contract for sibling apps. Shipped in two slices: entitlements + endpoint (4 backend tests, merged in #571) then launcher + docs (2 frontend tests); backend (608) + frontend (452) + AAR (54) suites, lint, and both typechecks green. `api_register.json` bumped to 1.4.0 with the new endpoint. **Deferred to Phase 2/3:** SSO redirect flow for cross-origin apps, shared `@rfs/*` packages, and coordinating the Santa Run / Fire Break repos to consume the endpoint.
@@ -1633,7 +1736,7 @@ Priority: **MEDIUM** - Long-term enhancements
 
 #### Feature: AI Voice (and Vision) Truck-Maintenance Agent
 **Status**: 📐 **DESIGN / FUTURE RELEASE** (design doc only — not implemented)
-**Design**: `docs/AI_MAINTENANCE_AGENT_DESIGN.md`
+**Design**: `docs/archive/AI_MAINTENANCE_AGENT_DESIGN.md` (roadmap: A1/A3/A4)
 
 **Objective**: A hands-free assistant that walks a volunteer through a truck check by
 voice ("I'm starting the Cat 1 tanker…"), prompting follow-ups in the same physical
@@ -1667,7 +1770,7 @@ the design doc for full detail.
 
 #### Feature: Self-Service Sign-up, Multi-Tenant Billing & Commercialization
 **Status**: 📐 **DESIGN / FUTURE RELEASE** (design doc only — not implemented)
-**Design**: `docs/SAAS_COMMERCIALIZATION_DESIGN.md`
+**Design**: `docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md` (roadmap: C1–C4)
 
 **Objective**: Turn Station Manager into a self-service SaaS — a brigade signs up online,
 picks a plan, pays via **Stripe**, enrols device-type accounts (kiosk/tablet/phone/
@@ -1705,15 +1808,15 @@ Stripe Price IDs. Phased A (tenant model) → B (billing+signup) → C (devices+
 #### Feature: "Bushie Tools" Suite — Multi-App Integration (Station Manager + AAR Studio + Fire Break Calculator + Fire Santa Run)
 **GitHub Issues**: [#556](https://github.com/richardthorek/Station-Manager/issues/556) (Phase 1 — federation) · [#557](https://github.com/richardthorek/Station-Manager/issues/557) (Phase 2 — shared packages) · [#558](https://github.com/richardthorek/Station-Manager/issues/558) (Phase 3 — monorepo)
 **Status**: 📐 **DESIGN / FUTURE RELEASE** (assessment + options only — not implemented)
-**Design**: `docs/SUITE_INTEGRATION_PLAN.md`. **Customer-facing name**: *Bushie
-Tools* (see the rebrand item in the Commercialization & coherence roadmap above) —
-this section is the technical integration plan behind that single brand.
+**Design**: `docs/archive/SUITE_INTEGRATION_PLAN.md` (roadmap: T6/T7).
+**Customer-facing name**: *Bushie Tools* (see the Consolidation & Standardisation
+Roadmap above) — this section is the technical integration plan behind that single brand.
 
 **Objective**: Deliver three sibling RFS/NSW apps — Station Manager (this repo),
 `fireBreakCalculator`, and `fire-santa-run` — as **one product suite** with a single
 sign-on, a single subscription, a consistent RFS brand/UX, and lower hosting/maintenance
 cost. Builds directly on the Organization/entitlements/Stripe model in
-`SAAS_COMMERCIALIZATION_DESIGN.md`, extending entitlements with per-app flags
+`archive/SAAS_COMMERCIALIZATION_DESIGN.md`, extending entitlements with per-app flags
 (`santaRunEnabled`, `fireBreakEnabled`, …).
 
 **Options (spectrum)**: A = federation (shared identity + subscription only, 3 deploys);
@@ -1724,7 +1827,7 @@ deployment (all four goals, highest effort). **Recommendation**: phase toward C
 **Auth recommendation**: decouple identity from entitlement — standardise authentication
 on **Microsoft Entra External ID** (already used by Santa Run; removes SM's custom
 password liability) while keeping SM's org+entitlements as the authZ/billing layer. NB:
-this would revise the JWT-retaining assumption in `SAAS_COMMERCIALIZATION_DESIGN.md` §2.
+this would revise the JWT-retaining assumption in `archive/SAAS_COMMERCIALIZATION_DESIGN.md` §2.
 
 **Open decisions**: integration depth (A/B/C); auth direction (Entra vs SM JWT);
 real-time standard for a unified backend (Socket.io vs Azure Web PubSub); plan/SKU shape.

--- a/docs/SUITE_TOKEN_VALIDATION.md
+++ b/docs/SUITE_TOKEN_VALIDATION.md
@@ -1,7 +1,9 @@
 # Bushie Tools — Suite Token Validation Protocol (Phase 1)
 
-**Status:** Implemented (suite Phase 1 — federation). See issue #556 and
-`docs/SUITE_INTEGRATION_PLAN.md` (Option A / Phase 1).
+**Status:** Implemented (suite Phase 1 — federation). See issue #556 and the
+Consolidation & Standardisation Roadmap (Suite convergence track) in
+`docs/MASTER_PLAN.md`; design history in `docs/archive/SUITE_INTEGRATION_PLAN.md`
+(Option A / Phase 1).
 
 This document is the contract sibling Bushie Tools apps (Fire Santa Run, Fire
 Break Calculator, and the AAR Studio sub-app) follow to authenticate a user and
@@ -11,7 +13,7 @@ read their entitlements against Station Manager, which acts as the canonical
 The model: **Station Manager's JWT is the suite identity provider (IdP).** A
 single sign-in mints a token; every app validates that same token and reads the
 same entitlements. (Microsoft Entra External ID was considered for authN — see
-`SUITE_INTEGRATION_PLAN.md` §5 — but SM JWT is retained because kiosk/station
+`archive/SUITE_INTEGRATION_PLAN.md` §5 — but SM JWT is retained because kiosk/station
 iPad devices authenticate with brigade access tokens rather than user accounts,
 a scenario the existing JWT/brigade-token model already supports without an
 external IdP.)
@@ -166,8 +168,9 @@ Sibling app ◀──token─────────────┘
 
 ## 6. Related
 
-- `docs/SUITE_INTEGRATION_PLAN.md` — full options analysis and phased roadmap.
-- `docs/SAAS_COMMERCIALIZATION_DESIGN.md` — Organization / plan / Stripe model.
+- `docs/MASTER_PLAN.md` — the single plan (Consolidation & Standardisation Roadmap).
+- `docs/archive/SUITE_INTEGRATION_PLAN.md` — full options analysis (design history).
+- `docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md` — Organization / plan / Stripe model (design history).
 - `backend/src/routes/auth.ts` — `GET /api/auth/entitlements` implementation.
 - `backend/src/constants/plans.ts` — plan → entitlement mapping.
 - `frontend/src/config/suiteApps.ts` — the launcher's sibling-app catalog.

--- a/docs/archive/AAR_STUDIO_PLAN.md
+++ b/docs/archive/AAR_STUDIO_PLAN.md
@@ -1,3 +1,10 @@
+> **⚠️ ARCHIVED — not a live plan.** AAR Studio's forward work (Stage 5 polish) is
+> tracked in `docs/MASTER_PLAN.md` ("Consolidation & Standardisation Roadmap" → AAR
+> Studio polish P1). Its **architecture of record** is `aar-studio/docs/ARCHITECTURE.md`.
+> Retained here for the stage history and data-model reference. Note: decision #2
+> ("browser → Azure direct, keys in localStorage; no server logic") is **superseded**
+> — #555 moved AAR's AI behind the server-side `/api/ai/*` gateway.
+
 # AAR Studio — Plan
 
 **Status:** Living document — update when scope or priorities change.

--- a/docs/archive/AI_MAINTENANCE_AGENT_DESIGN.md
+++ b/docs/archive/AI_MAINTENANCE_AGENT_DESIGN.md
@@ -1,3 +1,10 @@
+> **⚠️ ARCHIVED — not a live plan.** Folded into `docs/MASTER_PLAN.md`
+> ("Consolidation & Standardisation Roadmap" → AI maintenance agent track A1/A3/A4).
+> Retained for its load-bearing design detail — the new entity schemas
+> (`ApplianceZone`, `ApplianceEquipment`, `AgentSession`, `AgentTurn`), the additive
+> `Appliance`/`ChecklistItem`/`CheckRun`/`CheckResult` extensions, Table Storage
+> partitioning, and the agent tool contract — quote these verbatim when building.
+
 # Design: AI Voice (and Vision) Truck-Maintenance Agent
 
 **Status:** Draft / future release (design only — not yet implemented)

--- a/docs/archive/CONSOLIDATION_REVIEW.md
+++ b/docs/archive/CONSOLIDATION_REVIEW.md
@@ -1,3 +1,9 @@
+> **⚠️ ARCHIVED — not a live plan.** This design spike has been folded into the
+> single roadmap in `docs/MASTER_PLAN.md` ("Consolidation & Standardisation
+> Roadmap"). Forward status, priority, and sequencing live there. Retained here
+> for its detailed analysis (brand-divergence table, AI-gateway capability
+> registry, opportunity rationale) as historical reference only.
+
 # Cross-App Consolidation Review & Plan
 
 **Status:** Approved direction — implementation not yet started.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -14,6 +14,19 @@ Documents are moved here when they are no longer current, have been superseded b
 
 ## Contents
 
+### Superseded Planning & Design Spikes (folded into MASTER_PLAN, June 2026)
+
+These were standalone planning/design documents. Per the "one plan" policy, their
+forward work was consolidated into the **Consolidation & Standardisation Roadmap**
+in [`docs/MASTER_PLAN.md`](../MASTER_PLAN.md). They remain here for their detailed
+design content (schemas, pricing analysis, tool contracts) as reference only — they
+are **not** live plans.
+- **CONSOLIDATION_REVIEW.md** - cross-app coherence analysis, AI-gateway direction
+- **SUITE_INTEGRATION_PLAN.md** - "Bushie Tools" suite federation/monorepo options
+- **SAAS_COMMERCIALIZATION_DESIGN.md** - pricing analysis, Stripe surface, tenancy schema deltas
+- **AI_MAINTENANCE_AGENT_DESIGN.md** - voice/vision truck-maintenance agent schema & tool contract
+- **AAR_STUDIO_PLAN.md** - AAR Studio stage plan (architecture of record stays in `aar-studio/docs/ARCHITECTURE.md`)
+
 ### Completed Feature Implementation Summaries (2024-2026)
 
 **Admin & User Management:**

--- a/docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md
+++ b/docs/archive/SAAS_COMMERCIALIZATION_DESIGN.md
@@ -1,3 +1,9 @@
+> **⚠️ ARCHIVED — not a live plan.** Folded into `docs/MASTER_PLAN.md`
+> ("Consolidation & Standardisation Roadmap" → Commercialisation track + Pricing &
+> plans reference). Retained for its full pricing analysis (§7), Stripe surface,
+> cost model, and tenancy schema deltas — historical reference only. The live plan
+> catalog is `backend/src/constants/plans.ts`.
+
 # Design: Self-Service Sign-up, Multi-Tenant Billing & Commercialization
 
 **Status:** Partially shipped — see Implementation status below. The full

--- a/docs/archive/SUITE_INTEGRATION_PLAN.md
+++ b/docs/archive/SUITE_INTEGRATION_PLAN.md
@@ -1,3 +1,9 @@
+> **⚠️ ARCHIVED — not a live plan.** Folded into `docs/MASTER_PLAN.md`
+> ("Consolidation & Standardisation Roadmap" → Suite convergence track T6/T7).
+> Retained for its option analysis (A: federation / B: shared packages /
+> C: monorepo), the three-app comparison table, and the `@rfs/*` package layout —
+> historical reference only.
+
 # Design: "Bushie Tools" Suite — Integrating Station Manager, AAR Studio, Fire Break Calculator & Fire Santa Run
 
 **Status:** Draft / strategic design (assessment + options — not implemented)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,15 @@
 // ============================================
-// Multi-Station Support Types
+// Domain types (frontend mirror of the backend contract)
 // ============================================
+//
+// `backend/src/types/index.ts` is the **contract of record** for these domain
+// shapes. This file mirrors it for the wire: dates are `string` here (JSON
+// serialises Date → ISO string) where the backend uses `Date`. Keep the two in
+// sync — when the backend adds/changes a domain field, mirror it here.
+//
+// This drift (Date-vs-string + missing fields) is tracked as roadmap item T1 in
+// docs/MASTER_PLAN.md; increment 2 replaces these duplicate definitions with a
+// shared, date-generic module (`@rfs/types`).
 
 /**
  * Represents the hierarchical structure of RFS organization
@@ -33,6 +42,7 @@ export interface Station {
   };
   isActive: boolean;            // Whether station is currently active
   kioskToken?: string;          // Secure token for kiosk mode access (optional)
+  organizationId?: string;      // SaaS tenancy: owning Organization (optional for backward compat)
   createdAt: string;
   updatedAt: string;
 }
@@ -76,7 +86,10 @@ export interface Activity {
   id: string;
   name: string;
   isCustom: boolean;
+  category?: 'training' | 'maintenance' | 'meeting' | 'other';
+  tagColor?: string;             // CSS color or color name for UI tags
   createdBy?: string;
+  stationId?: string;            // Multi-station support (optional, shared activities use 'default')
   createdAt: string;
   isDeleted?: boolean;
 }
@@ -85,6 +98,7 @@ export interface CheckIn {
   id: string;
   memberId: string;
   activityId: string;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   checkInTime: string;
   checkInMethod: 'kiosk' | 'mobile' | 'qr';
   location?: string;
@@ -104,6 +118,7 @@ export interface CheckInWithDetails extends CheckIn {
 export interface ActiveActivity {
   id: string;
   activityId: string;
+  stationId?: string;            // Multi-station support (optional, each station has its own active activity)
   setAt: string;
   setBy?: string;
   activity?: Activity;
@@ -118,6 +133,7 @@ export interface Event {
   id: string;
   activityId: string;
   activityName: string;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   startTime: string;
   endTime?: string;
   isActive: boolean;
@@ -136,6 +152,7 @@ export interface EventParticipant {
   memberId: string;
   memberName: string;
   memberRank?: string | null;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   checkInTime: string;
   checkInMethod: 'kiosk' | 'mobile' | 'qr';
   location?: string;
@@ -163,6 +180,7 @@ export interface Appliance {
   name: string;
   description?: string;
   photoUrl?: string;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   /**
    * Canonical vehicle-type slug (e.g. 'cat1-pumper', 'cat7-tanker', 'bulk-water',
    * 'command'). A shared vocabulary lets reports group appliances of the same type
@@ -180,6 +198,7 @@ export interface ChecklistTemplate {
   id: string;
   applianceId: string;
   applianceName: string;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   items: ChecklistItem[];
   createdAt: string;
   updatedAt: string;
@@ -220,6 +239,7 @@ export interface CheckRun {
   id: string;
   applianceId: string;
   applianceName: string;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   startTime: string;
   endTime?: string;
   completedBy: string;
@@ -241,6 +261,7 @@ export interface CheckResult {
   itemId: string;
   itemName: string;
   itemDescription: string;
+  stationId?: string;            // Multi-station support (optional, defaults to 'default-station')
   /**
    * Canonical item-code copied from the checklist item at the time of the check.
    * Denormalised here so historical results stay comparable across brigades for trend


### PR DESCRIPTION
Answers "the tech stack across our features varies — should we consolidate and standardise?" with **one plan and the first standardisation increment**.

## 1. One plan, enforced

The repo had **six** planning/design docs drifting apart (MASTER_PLAN plus five spikes). This makes `docs/MASTER_PLAN.md` the **single plan** and collapses the rest into it.

- **New "Consolidation & Standardisation Roadmap" in MASTER_PLAN** — folds the five spikes into one ranked, status-tagged roadmap (🟢 shipped / ⬜ planned / 🟡 partial / 🔵 needs-decision), grouped into tracks: standardisation (shared types, design-system finish, AAR identity), commercialisation (Stripe, metering, devices), AI maintenance agent, suite convergence (Phases 2–3), and AAR polish. Includes a pricing reference table and the open decisions (D1–D5) that gate the work. It also reconciles the **stale "design only" headers** — #549/#550/#551/#554/#555/#556 have all shipped.
- **Policy strengthened** in MASTER_PLAN, `CLAUDE.md`, and `.github/copilot-instructions.md`: *there is exactly one plan; never create a new planning/design/roadmap doc — edit MASTER_PLAN.*
- **Five spikes archived** to `docs/archive/` with "⚠️ not a live plan" banners pointing back at the roadmap, preserving their detailed design content (schemas, pricing analysis, agent tool contract) as reference:
  - `CONSOLIDATION_REVIEW`, `SUITE_INTEGRATION_PLAN`, `SAAS_COMMERCIALIZATION_DESIGN`, `AI_MAINTENANCE_AGENT_DESIGN`, and AAR Studio's `PLAN.md` → `AAR_STUDIO_PLAN.md`. (AAR's architecture of record stays in `aar-studio/docs/ARCHITECTURE.md`.)
- **All live references repointed** — CLAUDE.md, README, `SUITE_TOKEN_VALIDATION.md`, the archive index, and code comments in `plans.ts` / `ai.ts` / `meteredUsageReporter.ts` — to MASTER_PLAN + the new archive paths.

## 2. Start work — roadmap item T1 (shared domain types), increment 1

The clearest symptom of "tech stack varies": `Station`/`Member`/truck-check types are defined twice (`backend/src/types` vs `frontend/src/types`) and had **drifted** — the frontend mirror had lost `stationId` on nine interfaces, `Activity.category`/`tagColor`, and `Station.organizationId`.

- **Re-synced `frontend/src/types` to the backend contract of record** (all additions optional/additive → zero behavioural change), and documented the backend types as the contract and the `Date`-vs-`string` wire relationship.
- Roadmap **T1 increment 2** (extract a real shared `@rfs/types` module with a date-generic, riding the npm-workspace foundation from suite Phase 2) is queued as the next step.

## Test plan
- [x] Backend typecheck + **615 tests**
- [x] Frontend lint + typecheck + **452 tests**
- [x] AAR Studio **54 tests** (`node --test`)
- [x] Registry validation (`scripts/validate-registries.sh`)
- [x] Production build (`npm run build`)

No source logic changed (type additions + doc/comment edits only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi4MZkeHFE1EU5WiPn2q4S)_