### PR TITLE
feat(aar): per-unit finding attribution (P1)

### DIFF
--- a/aar-studio/css/app.css
+++ b/aar-studio/css/app.css
@@ -210,6 +210,7 @@ input:focus, select:focus, textarea:focus, .btn:focus-visible {
 .chip--phase { background: #e8edf1; }
 .chip--ai { background: #fdf3d7; color: #7a5c00; }
 .chip--manual { background: #e2f0e8; color: var(--good); }
+.chip--unit { background: #e4e9f5; color: #2f3e63; font-weight: 600; }
 .chip--done { background: #e2f0e8; color: var(--good); }
 .chip--filter { cursor: pointer; font-size: 0.82rem; padding: 0.3rem 0.9rem; min-height: var(--tap-min-sm); display: inline-flex; align-items: center; }
 .chip--filter:hover { border-color: var(--ink); }

--- a/aar-studio/docs/ARCHITECTURE.md
+++ b/aar-studio/docs/ARCHITECTURE.md
@@ -67,9 +67,10 @@ uses only `fetch`, so it is loadable under node for tests.
     "id": "uuid",
     "category": "happened" | "well" | "didnt" | "next",
     "phase": "Suppression",            // any session phase or "General"
+    "unit": "",                        // optional attending-unit attribution (sessionUnitNames)
     "text": "", "quote": "",          // short verbatim quote
     "segmentIds": ["..."],
-    "source": "ai" | "manual",
+    "source": "ai" | "manual" | "merged",
     "createdAt": "ISO"
   } ],
   "speakers": { "Speaker 1": "Dave (Wamboin captain)" },  // rename map

--- a/aar-studio/js/lib/exports.js
+++ b/aar-studio/js/lib/exports.js
@@ -301,20 +301,25 @@ function summarySection(session) {
 
 function registerSection(session) {
   if (!session.findings?.length) return '';
+  // Only show the Unit column when at least one finding is attributed, so
+  // reviews that don't track units aren't cluttered with an empty column.
+  const hasUnits = session.findings.some((f) => f.unit);
   const rows = [];
   for (const phase of sessionPhases(session)) {
     for (const cat of CATEGORIES) {
       for (const f of session.findings.filter((x) => x.phase === phase && x.category === cat.id)) {
         const quote = f.quote ? `<div class="quote">&ldquo;${esc(f.quote)}&rdquo;</div>` : '';
-        rows.push(`<tr><td>${esc(phase)}</td><td class="cat">${esc(cat.short)}</td><td>${esc(f.text)}${quote}</td></tr>`);
+        const unitCell = hasUnits ? `<td class="unit">${f.unit ? esc(f.unit) : '—'}</td>` : '';
+        rows.push(`<tr><td>${esc(phase)}</td><td class="cat">${esc(cat.short)}</td>${unitCell}<td>${esc(f.text)}${quote}</td></tr>`);
       }
     }
   }
+  const unitHead = hasUnits ? '<th>Unit</th>' : '';
   return `<div class="doc pagebreak">
 <h1>Findings register</h1>
 <p class="meta">${session.findings.length} findings captured during the AAR.</p>
 <table class="register">
-<thead><tr><th>Phase</th><th>Category</th><th>Finding</th></tr></thead>
+<thead><tr><th>Phase</th><th>Category</th>${unitHead}<th>Finding</th></tr></thead>
 <tbody>${rows.join('\n')}</tbody>
 </table>
 </div>`;

--- a/aar-studio/js/lib/model.js
+++ b/aar-studio/js/lib/model.js
@@ -57,9 +57,15 @@ export function createSegment({ t = null, speaker = '', text = '', phase = GENER
   return { id: uid(), t, speaker, text, phase, source, analysed: false };
 }
 
-export function createFinding({ category, phase = GENERAL_PHASE, text = '', quote = '', segmentIds = [], source = 'manual' }) {
+export function createFinding({ category, phase = GENERAL_PHASE, text = '', quote = '', unit = '', segmentIds = [], source = 'manual' }) {
   if (!CATEGORY_IDS.includes(category)) category = 'happened';
-  return { id: uid(), category, phase, text, quote, segmentIds, source, createdAt: new Date().toISOString() };
+  return { id: uid(), category, phase, unit: String(unit ?? ''), text, quote, segmentIds, source, createdAt: new Date().toISOString() };
+}
+
+/** Distinct, non-empty attending-unit names — the options for tagging a finding to a unit. */
+export function sessionUnitNames(session) {
+  const names = (session?.units ?? []).map((u) => String(u.unit ?? '').trim()).filter(Boolean);
+  return [...new Set(names)];
 }
 
 /**
@@ -117,6 +123,7 @@ export function normaliseSession(obj) {
     ...createFinding({ category: f.category }), ...f,
     id: f.id || uid(),
     category: CATEGORY_IDS.includes(f.category) ? f.category : 'happened',
+    unit: String(f.unit ?? ''),
     segmentIds: Array.isArray(f.segmentIds) ? f.segmentIds : [],
   }));
   s.notes = (Array.isArray(obj.notes) ? obj.notes : []).map((n) => ({

--- a/aar-studio/js/views/board.js
+++ b/aar-studio/js/views/board.js
@@ -3,7 +3,7 @@
 
 import { h, toast } from '../ui.js';
 import * as store from '../store.js';
-import { CATEGORIES, sessionPhases, createFinding } from '../lib/model.js';
+import { CATEGORIES, sessionPhases, sessionUnitNames, createFinding } from '../lib/model.js';
 import { findMergeSuggestions, mergeFindings } from '../lib/dedupe.js';
 import { analyseNow } from '../analyse.js';
 
@@ -13,6 +13,14 @@ let phaseFilter = null; // null = all
 const dismissedPairs = new Set();
 
 const pairKey = (a, b) => [a.id, b.id].sort().join('|');
+
+/** A unit-attribution <select>: a blank "no unit" option plus each attending unit. */
+function unitSelect(units, selected = '') {
+  return h('select', { 'aria-label': 'Attribute finding to a unit' },
+    h('option', { value: '', selected: !selected }, '— no unit'),
+    units.map((u) => h('option', { value: u, selected: u === selected }, u)),
+  );
+}
 
 function mergeSuggestionsPanel(session) {
   const suggestions = findMergeSuggestions(session.findings)
@@ -59,13 +67,14 @@ function mergeSuggestionsPanel(session) {
   );
 }
 
-function findingCard(f, phases) {
+function findingCard(f, phases, units) {
   const card = h('div', { class: `finding finding--${f.category}`, role: 'listitem' });
   const body = h('div', { class: 'finding__text' }, f.text);
   card.append(
     body,
     h('div', { class: 'finding__meta' },
       h('span', { class: 'chip chip--phase' }, f.phase),
+      f.unit ? h('span', { class: 'chip chip--unit', title: `Attributed to ${f.unit}` }, f.unit) : null,
       f.source === 'ai' ? h('span', { class: 'chip chip--ai', title: f.quote ? `“${f.quote}”` : 'AI extracted' }, 'AI') : null,
       h('span', { class: 'finding__tools' },
         h('button', { class: 'icon-btn', title: 'Edit', 'aria-label': 'Edit finding', onclick: () => editInline() }, '✎'),
@@ -79,14 +88,15 @@ function findingCard(f, phases) {
     const textArea = h('textarea', { rows: 3 }, f.text);
     const catSel = h('select', {}, CATEGORIES.map((c) => h('option', { value: c.id, selected: c.id === f.category }, c.label)));
     const phaseSel = h('select', {}, phases.map((p) => h('option', { value: p, selected: p === f.phase }, p)));
+    const unitSel = units.length ? unitSelect(units, f.unit) : null;
     const editor = h('div', { class: 'finding__editor' },
       textArea,
       h('div', { class: 'btn-row' },
-        catSel, phaseSel,
+        catSel, phaseSel, unitSel,
         h('button', { class: 'btn btn--small btn--primary', onclick: () => {
           store.update((s) => {
             const target = s.findings.find((x) => x.id === f.id);
-            if (target) Object.assign(target, { text: textArea.value.trim(), category: catSel.value, phase: phaseSel.value });
+            if (target) Object.assign(target, { text: textArea.value.trim(), category: catSel.value, phase: phaseSel.value, unit: unitSel ? unitSel.value : f.unit });
           }, { reason: 'findings' });
         } }, 'Save'),
         h('button', { class: 'btn btn--small', onclick: () => store.update(() => {}, { reason: 'findings' }) }, 'Cancel'),
@@ -99,19 +109,20 @@ function findingCard(f, phases) {
   return card;
 }
 
-function quickAdd(phases) {
+function quickAdd(phases, units) {
   const input = h('input', { type: 'text', placeholder: 'Quick-add a finding…', class: 'quick-add__input' });
   const catSel = h('select', {}, CATEGORIES.map((c) => h('option', { value: c.id }, c.label)));
   const phaseSel = h('select', {}, phases.map((p) => h('option', { value: p, selected: p === store.getSession().currentPhase }, p)));
+  const unitSel = units.length ? unitSelect(units) : null;
   const add = () => {
     if (!input.value.trim()) return;
     store.update((s) => {
-      s.findings.push(createFinding({ category: catSel.value, phase: phaseSel.value, text: input.value.trim(), source: 'manual' }));
+      s.findings.push(createFinding({ category: catSel.value, phase: phaseSel.value, unit: unitSel ? unitSel.value : '', text: input.value.trim(), source: 'manual' }));
     }, { reason: 'findings' });
     toast('Finding added');
   };
   input.addEventListener('keydown', (e) => { if (e.key === 'Enter') add(); });
-  return h('div', { class: 'quick-add' }, input, catSel, phaseSel, h('button', { class: 'btn btn--primary', onclick: add }, 'Add'));
+  return h('div', { class: 'quick-add' }, input, catSel, phaseSel, unitSel, h('button', { class: 'btn btn--primary', onclick: add }, 'Add'));
 }
 
 function togglePresent() {
@@ -123,6 +134,7 @@ function togglePresent() {
 export function render(container) {
   const session = store.getSession();
   const phases = sessionPhases(session);
+  const units = sessionUnitNames(session);
   if (phaseFilter && !phases.includes(phaseFilter)) phaseFilter = null;
   const status = h('span', { class: 'muted', role: 'status', 'aria-live': 'polite' });
 
@@ -141,7 +153,7 @@ export function render(container) {
     return h('div', { class: `board__col board__col--${cat.id}`, role: 'group', 'aria-label': `${cat.label} (${items.length})` },
       h('div', { class: 'board__head' }, h('span', {}, cat.label), h('span', { class: 'board__count', 'aria-hidden': 'true' }, String(items.length))),
       h('div', { class: 'board__cards', role: 'list' },
-        items.length ? items.map((f) => findingCard(f, phases)) : h('p', { class: 'muted board__empty' }, '—'),
+        items.length ? items.map((f) => findingCard(f, phases, units)) : h('p', { class: 'muted board__empty' }, '—'),
       ),
     );
   }));
@@ -163,7 +175,7 @@ export function render(container) {
     ),
     filterChips,
     mergeSuggestionsPanel(session),
-    quickAdd(phases),
+    quickAdd(phases, units),
     columns,
     h('button', { class: 'present-exit btn', onclick: togglePresent }, 'Exit present mode (Esc)'),
   );

--- a/aar-studio/test/unitAttribution.test.js
+++ b/aar-studio/test/unitAttribution.test.js
@@ -1,0 +1,53 @@
+// Per-unit finding attribution (P1).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSession, createFinding, sessionUnitNames, normaliseSession } from '../js/lib/model.js';
+import { renderCombinedHtml } from '../js/lib/exports.js';
+
+test('createFinding defaults unit to empty and keeps an explicit unit', () => {
+  assert.equal(createFinding({ category: 'well', text: 'x' }).unit, '');
+  assert.equal(createFinding({ category: 'well', text: 'x', unit: 'Bungendore 1' }).unit, 'Bungendore 1');
+  // non-string units are coerced
+  assert.equal(createFinding({ category: 'well', text: 'x', unit: null }).unit, '');
+});
+
+test('sessionUnitNames returns distinct, trimmed, non-empty unit names', () => {
+  const s = createSession({ units: [
+    { unit: 'Bungendore 1', role: 'Pump' },
+    { unit: '  Wamboin 7 ', role: 'Tanker' },
+    { unit: '', role: 'spare row' },
+    { unit: 'Bungendore 1', role: 'duplicate' },
+  ] });
+  assert.deepEqual(sessionUnitNames(s), ['Bungendore 1', 'Wamboin 7']);
+});
+
+test('normaliseSession coerces and backfills finding.unit', () => {
+  const s = normaliseSession({
+    incident: { title: 'T' }, aar: {}, units: [],
+    findings: [
+      { category: 'didnt', text: 'a', unit: 'Cat 1' },
+      { category: 'well', text: 'b' }, // missing unit
+    ],
+    segments: [],
+  });
+  assert.equal(s.findings[0].unit, 'Cat 1');
+  assert.equal(s.findings[1].unit, '');
+});
+
+test('findings register shows a Unit column only when a finding is attributed', () => {
+  const withUnit = createSession({
+    incident: { title: 'Job' }, units: [{ unit: 'Cat 1', role: 'Pump' }],
+    findings: [createFinding({ category: 'didnt', text: 'Pump too close', unit: 'Cat 1' })],
+    report: null,
+  });
+  const html = renderCombinedHtml(withUnit);
+  assert.match(html, /<th>Unit<\/th>/);
+  assert.match(html, /Cat 1/);
+
+  const noUnit = createSession({
+    incident: { title: 'Job' }, units: [],
+    findings: [createFinding({ category: 'didnt', text: 'Pump too close' })],
+    report: null,
+  });
+  assert.ok(!renderCombinedHtml(noUnit).includes('<th>Unit</th>'));
+});

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -303,8 +303,14 @@ Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision 
   are `role=group` labelled by category, cards are a `role=list`/`listitem`
   structure, the analyse status is an `aria-live` region, and the merge panel is a
   labelled region with accessible buttons. 4 new pure-function tests (AAR suite 89).
-  *Remaining:* print-stylesheet refinements; per-unit finding attribution; optional
-  `?demo` deep link. (archive: AAR_STUDIO_PLAN Stage 5)
+  *Per-unit finding attribution done 2026-06-23:* findings now carry an optional
+  `unit` (model `createFinding`/`normaliseSession` + `sessionUnitNames` helper);
+  the board quick-add and inline editor expose a unit `<select>` (populated from the
+  session's attending units), the card shows a `chip--unit`, and the report's findings
+  register adds a **Unit** column when any finding is attributed (omitted otherwise).
+  4 new tests (AAR suite 93).
+  *Remaining:* print-stylesheet refinements; optional `?demo` deep link.
+  (archive: AAR_STUDIO_PLAN Stage 5)
 
 ### Pricing & plans (reference)
 
@@ -2850,6 +2856,7 @@ curl -H "Origin: https://malicious-site.com" \
 | 4.4 | Jun 2026 | T1 inc 2 — shared domain types | Extracted the core sign-in domain shapes into a single date-generic, declaration-only `shared/domain-types.d.ts` (`Member<TDate = string>` etc.). Backend re-exports specialised with `Date`, frontend with `string`. Type-only `.d.ts` is never emitted/bundled, so install, both `dist` outputs, and CI deploy packaging are untouched (deliberately avoids the T6 npm-workspace conflict). All CI gates green. |
 | 4.5 | Jun 2026 | S1 closed | Design-system pass closed: AAR Studio global `prefers-reduced-motion` guard shipped (#587); strict-60px declined by owner (AAR is a desktop facilitator tool); shared report-template sub-item investigated and closed as not-actionable — the three "export paths" use three different mechanisms (CSV / jsPDF+html2canvas / HTML) with no duplicated template to extract. |
 | 4.6 | Jun 2026 | AAR P1 (merge UI) | AAR findings board gained a "Possible duplicates" merge-suggestion panel: dedupe now has a two-band model (auto-skip ≥0.72; soft-band [0.5,0.72) surfaced for human merge via `findMergeSuggestions`/`mergeFindings`), with Merge / Keep-both actions and an accessibility pass (role=group/list columns, aria-live status, labelled merge region). 4 new pure tests; AAR suite 89. |
+| 4.7 | Jun 2026 | AAR P1 (unit attribution) | AAR findings can be attributed to an attending unit: optional `unit` on the finding model (`createFinding`/`normaliseSession` + `sessionUnitNames`), a unit `<select>` on board quick-add + inline edit, a `chip--unit` on cards, and a conditional **Unit** column in the report's findings register. 4 new tests; AAR suite 93. |
 
 ---
 


### PR DESCRIPTION
## Summary

Next AAR Studio **P1** slice: **per-unit finding attribution**. A finding can now be tagged to one of the session's attending units, so a review records *which appliance/crew* a point relates to, and the report can be read per-unit. Entirely within `aar-studio/`.

## What shipped

**Model** (`js/lib/model.js`, pure):
- Findings carry an optional `unit` (`createFinding` default `''`; `normaliseSession` coerces/backfills so older exports still load).
- New `sessionUnitNames(session)` — distinct, trimmed, non-empty attending-unit names; the option source for tagging.

**Board** (`js/views/board.js`):
- A unit `<select>` ("— no unit" + each attending unit) on **quick-add** and the **inline editor**, shown only when the session has attending units (no clutter for reviews that don't track them).
- Cards show a `chip--unit` when attributed.

**Report** (`js/lib/exports.js`):
- The findings register gains a **Unit** column — but only when at least one finding is attributed; unattributed reviews keep the original 3-column table.

## Tests
4 new tests in `test/unitAttribution.test.js` (unit default/coercion, `sessionUnitNames` de-dup/trim, register column appears only when attributed). **AAR suite 89 → 93.** `node --check` clean on the modified modules.

## Notes
- Screenshots not captured — AAR is a no-build static app served at `/aar` and this headless environment has no browser to drive it. The unit `<select>` reuses the existing quick-add/editor control row; the chip uses the established `.chip` token styling.
- Docs: `aar-studio/docs/ARCHITECTURE.md` (session schema) and `docs/MASTER_PLAN.md` (P1, version 4.7) updated.
- Remaining P1 slices: print-stylesheet refinements, optional `?demo` deep link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_