### PR TITLE
feat(aar): ?demo deep link loads the example review (P1)

### DIFF
--- a/aar-studio/README.md
+++ b/aar-studio/README.md
@@ -48,7 +48,8 @@ heavy lifting.** You can fill in details if you want to, but you never have to.
    report, Markdown summary, a backup file, or print to PDF.
 
 Choose **See an example** on the home screen to explore a finished review
-without any Azure setup.
+without any Azure setup — or open the app with `?demo` (e.g. `/aar/?demo`) to
+jump straight into that example, handy for sharing a walkthrough link.
 
 ## Local development
 

--- a/aar-studio/docs/ARCHITECTURE.md
+++ b/aar-studio/docs/ARCHITECTURE.md
@@ -174,3 +174,11 @@ pass on stop. Pure helpers (resampling, RMS, speaker labels) live in
   probe failures all proceed. This is a UX gate only; the security boundary is
   the backend `requireFeature('aarStudioEnabled')` already on `/api/aar-sessions`
   and the AI-gateway routes, which 403/503 an unentitled org regardless.
+
+- **`?demo` deep link.** Loading `/aar/?demo` (after the plan gate passes) loads
+  the bundled `data/sample-session.json` example straight onto the findings board
+  — a shareable walkthrough link. `main.js` strips the query with
+  `history.replaceState` once loaded, so a later reload returns to the normal home
+  rather than re-clobbering the session. Fails open: if the example can't be
+  fetched it falls through to a normal boot. Shares the `loadExampleSession()`
+  loader with the home view's "See an example" button.

--- a/aar-studio/js/main.js
+++ b/aar-studio/js/main.js
@@ -111,6 +111,19 @@ async function boot() {
     renderGate();
     return;
   }
+  // `?demo` deep link: load the bundled example review straight onto the board
+  // (for sharing a walkthrough link). Strip the query afterwards so a later
+  // reload returns to the normal home rather than clobbering the session again.
+  // Fails open — if the example can't be fetched, fall through to a normal boot.
+  if (new URLSearchParams(location.search).has('demo')) {
+    try {
+      await home.loadExampleSession();
+      history.replaceState(null, '', location.pathname + location.hash);
+      return;
+    } catch {
+      // ignore and boot normally
+    }
+  }
   store.resumeLastSession();
   if (!location.hash) location.hash = store.getSession() ? '#/board' : '#/home';
   render();

--- a/aar-studio/js/views/home.js
+++ b/aar-studio/js/views/home.js
@@ -26,7 +26,11 @@ function setUpFirst() {
   location.hash = '#/setup';
 }
 
-async function loadExample() {
+/**
+ * Load the bundled example review and land on the findings board. Reused by the
+ * "See an example" button and the `?demo` deep link (main.js boot).
+ */
+export async function loadExampleSession() {
   const res = await fetch('./data/sample-session.json');
   if (!res.ok) throw new Error(`Example not available (${res.status})`);
   store.importSessionJson(await res.text());
@@ -166,7 +170,7 @@ export function render(container) {
         : h('p', { class: 'muted' }, 'No reviews yet. Hit “Start recording now” at the end of your next job.'),
     ),
     h('section', { class: 'home-footer' },
-      h('button', { class: 'link-btn', onclick: () => loadExample().catch((e) => toast(e.message, 'error')) }, 'See an example'),
+      h('button', { class: 'link-btn', onclick: () => loadExampleSession().catch((e) => toast(e.message, 'error')) }, 'See an example'),
       h('span', { class: 'home-footer__sep' }, '·'),
       h('button', { class: 'link-btn', onclick: openSavedFile }, 'Open a saved review file'),
     ),

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -309,8 +309,13 @@ Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision 
   session's attending units), the card shows a `chip--unit`, and the report's findings
   register adds a **Unit** column when any finding is attributed (omitted otherwise).
   4 new tests (AAR suite 93).
-  *Remaining:* print-stylesheet refinements; optional `?demo` deep link.
-  (archive: AAR_STUDIO_PLAN Stage 5)
+  *`?demo` deep link done 2026-06-23:* `/aar/?demo` loads the bundled example review
+  straight onto the board (shareable walkthrough link); `main.js` strips the query via
+  `history.replaceState` after loading so a reload returns to home, fails open if the
+  example can't be fetched, and shares the `loadExampleSession()` loader with the
+  "See an example" button.
+  *Remaining:* print-stylesheet refinements (visual; needs a browser to verify) —
+  the only open P1 item. (archive: AAR_STUDIO_PLAN Stage 5)
 
 ### Pricing & plans (reference)
 
@@ -2857,6 +2862,7 @@ curl -H "Origin: https://malicious-site.com" \
 | 4.5 | Jun 2026 | S1 closed | Design-system pass closed: AAR Studio global `prefers-reduced-motion` guard shipped (#587); strict-60px declined by owner (AAR is a desktop facilitator tool); shared report-template sub-item investigated and closed as not-actionable — the three "export paths" use three different mechanisms (CSV / jsPDF+html2canvas / HTML) with no duplicated template to extract. |
 | 4.6 | Jun 2026 | AAR P1 (merge UI) | AAR findings board gained a "Possible duplicates" merge-suggestion panel: dedupe now has a two-band model (auto-skip ≥0.72; soft-band [0.5,0.72) surfaced for human merge via `findMergeSuggestions`/`mergeFindings`), with Merge / Keep-both actions and an accessibility pass (role=group/list columns, aria-live status, labelled merge region). 4 new pure tests; AAR suite 89. |
 | 4.7 | Jun 2026 | AAR P1 (unit attribution) | AAR findings can be attributed to an attending unit: optional `unit` on the finding model (`createFinding`/`normaliseSession` + `sessionUnitNames`), a unit `<select>` on board quick-add + inline edit, a `chip--unit` on cards, and a conditional **Unit** column in the report's findings register. 4 new tests; AAR suite 93. |
+| 4.8 | Jun 2026 | AAR P1 (`?demo` deep link) | `/aar/?demo` loads the bundled example review straight onto the findings board (shareable walkthrough link); `main.js` strips the query after loading, fails open if the example can't be fetched, and reuses the home view's `loadExampleSession()` loader. Only print-stylesheet refinements remain in P1. |
 
 ---
 


### PR DESCRIPTION
## Summary

Next AAR Studio **P1** slice: a **`?demo` deep link**. Opening `/aar/?demo` loads the bundled example review straight onto the findings board — a shareable walkthrough link that needs no Azure setup or sign-in.

## What shipped
- `main.js` boot: when `?demo` is present (after the plan gate passes), load the example and land on the board, then `history.replaceState` to strip the query so a later reload returns to the normal home rather than re-clobbering the session. **Fails open** — if the example can't be fetched, falls through to a normal boot.
- Factored the home view's example loader into an exported `loadExampleSession()`, so the "See an example" button and the deep link share one code path (no duplication).

## Tests / verification
`node --check` clean on `main.js` and `home.js`; **AAR suite 93 pass**. This is boot/DOM glue (fetch + `location` + `history`), consistent with `main.js` boot not being unit-tested — the underlying import path (`loadExampleSession` → `store.importSessionJson`) is already exercised by the existing example/import tests.

## Notes
- No screenshots — headless environment, no browser to drive `/aar`.
- Docs: `aar-studio/docs/ARCHITECTURE.md`, `aar-studio/README.md`, `docs/MASTER_PLAN.md` (P1, version 4.8) updated.
- **Only print-stylesheet refinements remain in P1** — that one is inherently visual and wants a browser to verify, so it's a good candidate to pair with a screenshot pass or hand off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_