### PR TITLE
fix(smoke): members endpoint is auth-gated — expect 401, not 200

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,11 @@ Organizations are the billing tenant; features are gated per-org. Default-**off*
   and a matching `<FeatureRoute>` in the frontend; gating `/api/export` behind
   `reportsEnabled` and enforcing `maxStations` on `POST /api/stations` are live
   examples. See `backend/src/middleware/entitlements.ts`.
-- Post-deployment smoke tests are disabled in CI (need ts-node, prod has no dev
-  deps). Don't rely on them.
+- Post-deployment smoke tests **do run on `main` deploys** (`npm run test:post-deploy`
+  → compiled `backend/dist/scripts/postDeploymentTests.js`, hitting the live
+  `bungrfs-linux` app); they are skipped on PRs. They assert live-endpoint behaviour, so
+  a deliberate API/auth change (e.g. the `requireSession` data-protection gate makes
+  `GET /api/members` return 401 to anonymous callers) must be reflected in
+  `postDeploymentTests.ts` or the `main` run fails *after* the PR merged green.
 - Node 22.x / npm ≥ 10 required.
 </content>

--- a/backend/src/scripts/postDeploymentTests.ts
+++ b/backend/src/scripts/postDeploymentTests.ts
@@ -375,19 +375,18 @@ async function testGetActivities(): Promise<void> {
 }
 
 /**
- * Functional Test 4: Get Members Endpoint
+ * Functional Test 4: Members endpoint is auth-gated (data-protection gate).
+ *
+ * `GET /api/members` is protected by `requireSession({ readsOnly })` (the
+ * anonymous data-exposure fix). An unauthenticated request must be rejected with
+ * 401 — so this smoke test verifies the gate is actually live in production
+ * (a 200 here would mean member PII is exposed to anonymous callers again).
  */
 async function testGetMembers(): Promise<void> {
   const response = await makeRequest(`${APP_URL}/api/members`);
-  
-  if (response.statusCode !== 200) {
-    throw new Error(`Expected status 200, got ${response.statusCode}`);
-  }
 
-  const data = JSON.parse(response.data);
-  
-  if (!Array.isArray(data)) {
-    throw new Error('Expected members to be an array');
+  if (response.statusCode !== 401) {
+    throw new Error(`Expected 401 (auth-gated), got ${response.statusCode} — member data must not be readable anonymously`);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the **post-deployment smoke-test failure** on `main` (flagged from the #592 deploy run). The failure was **not** a unit test — it's the live-endpoint smoke suite that runs on `main` deploys:

```
Members API... ❌ FAIL — Error: Expected status 200, got 401
```

## Root cause
`testGetMembers` makes an **unauthenticated** `GET /api/members` and expected `200`. Since **#587** added the `requireSession({ readsOnly })` data-protection gate (the anonymous-data-exposure fix), that endpoint now correctly returns **401** to anonymous callers. So the smoke test has been asserting the *old, insecure* behaviour and failing on every `main` deploy since #587 — it surfaced now on the #592 merge run.

Not specific to #592 (which was AAR-only) — the AAR PRs just happened to be the deploys that re-ran it.

## Fix
- `testGetMembers` now expects **401**, which turns it into a *meaningful security smoke test*: a `200` here would mean member PII is readable anonymously again. Verified against `index.ts` — `/api/members` is `requireSession`-gated; `/api/activities` and `/api/checkins` (the other 200-expecting checks) are not gated, and `/api/reports`/`/api/truck-checks` aren't in the smoke suite.
- Corrects the stale `CLAUDE.md` note claiming smoke tests are disabled in CI — they **do** run on `main` deploys (`npm run test:post-deploy`) and assert live behaviour, so deliberate API/auth changes must be reflected there.

## Verification
Backend typecheck clean. The smoke suite only runs on `main` deploys (skipped on PRs), so this PR's CI validates build/typecheck; the real validation is the **next `main` deploy** going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_