### PR TITLE
feat(truck-check): ChecklistItem zone/equipment links (A1 inc 3)

### DIFF
--- a/backend/src/__tests__/checklistItemZoneLinks.test.ts
+++ b/backend/src/__tests__/checklistItemZoneLinks.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A1 inc 3 — ChecklistItem zone/equipment links + response metadata.
+ *
+ * The new optional fields (zoneId, equipmentId, expectedResponseType, unit,
+ * promptHint) must round-trip through BOTH checklist persistence paths:
+ *   - a brigade's per-appliance custom overlay (template), and
+ *   - a VehicleType's locked standard items.
+ * These are the link that makes the per-truck zone/equipment model useful.
+ */
+
+jest.mock('../index');
+
+import request from 'supertest';
+import express, { Express } from 'express';
+import jwt from 'jsonwebtoken';
+import truckChecksRouter from '../routes/truckChecks';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-in-production';
+const adminAuth = () => ({
+  Authorization: `Bearer ${jwt.sign({ userId: 'a1', username: 'a1', role: 'admin', organizationId: 'org-links' }, JWT_SECRET)}`,
+});
+
+let app: Express;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.set('io', { emit: jest.fn(), to: jest.fn().mockReturnThis() });
+  app.use('/api/truck-checks', truckChecksRouter);
+});
+
+describe('ChecklistItem zone/equipment links — custom overlay round-trip', () => {
+  it('preserves zoneId/equipmentId/expectedResponseType/unit/promptHint through save + effective checklist', async () => {
+    const appliance = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Links Truck' }).expect(201);
+    const applianceId = appliance.body.id;
+
+    const customItems = [{
+      id: 'ci-1', name: 'Primary pump pressure', description: 'Read the gauge',
+      order: 0,
+      zoneId: 'zone-pump-panel',
+      equipmentId: 'equip-akron',
+      expectedResponseType: 'numeric',
+      unit: 'psi',
+      promptHint: 'Ask for the reading at idle',
+    }];
+
+    await request(app)
+      .put(`/api/truck-checks/appliances/${applianceId}/checklist`)
+      .send({ customItems, itemOrder: ['ci-1'] }).expect(200);
+
+    const res = await request(app)
+      .get(`/api/truck-checks/appliances/${applianceId}/checklist`).expect(200);
+
+    const item = res.body.items.find((i: { name: string }) => i.name === 'Primary pump pressure');
+    expect(item).toBeDefined();
+    expect(item.zoneId).toBe('zone-pump-panel');
+    expect(item.equipmentId).toBe('equip-akron');
+    expect(item.expectedResponseType).toBe('numeric');
+    expect(item.unit).toBe('psi');
+    expect(item.promptHint).toBe('Ask for the reading at idle');
+    expect(item.isStandard).toBe(false);
+  });
+});
+
+describe('ChecklistItem zone/equipment links — VehicleType standard items round-trip', () => {
+  it('preserves the new fields on a VehicleType standardItems through create + list', async () => {
+    const standardItems = [{
+      name: 'Foam tank level', description: 'Check level',
+      zoneId: 'zone-tank',
+      expectedResponseType: 'level',
+      promptHint: 'low / half / full',
+    }];
+
+    const created = await request(app)
+      .post('/api/truck-checks/vehicle-types')
+      .set(adminAuth())
+      .send({ name: 'Links Cat 1', standardItems }).expect(201);
+
+    // normaliseStandardItems forces id/order/itemCode/isStandard but must keep extras.
+    const item = created.body.standardItems[0];
+    expect(item.zoneId).toBe('zone-tank');
+    expect(item.expectedResponseType).toBe('level');
+    expect(item.promptHint).toBe('low / half / full');
+    expect(item.isStandard).toBe(true);
+    expect(item.itemCode).toBe('foam-tank-level');
+
+    const list = await request(app)
+      .get('/api/truck-checks/vehicle-types').set(adminAuth()).expect(200);
+    const listed = list.body.find((t: { id: string }) => t.id === created.body.id);
+    expect(listed.standardItems[0].zoneId).toBe('zone-tank');
+    expect(listed.standardItems[0].expectedResponseType).toBe('level');
+  });
+});

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -444,6 +444,24 @@ export interface ChecklistItem {
    * Used to render the checklist in sections. Optional.
    */
   section?: string;
+  /**
+   * A1 — link to an ApplianceZone (richer than the flat `section` string). When
+   * present, the maintenance agent can group the check by physical area and walk
+   * it in zone order. Optional / back-compatible.
+   */
+  zoneId?: string;
+  /** A1 — this item checks a specific ApplianceEquipment piece (optional). */
+  equipmentId?: string;
+  /**
+   * A1 — shape of the expected answer, so the agent knows how to ask/parse:
+   * 'ok-issue' (default pass/fail), 'numeric' (a reading + `unit`), 'level'
+   * (e.g. low/half/full), or free 'text'. Optional; absent = 'ok-issue'.
+   */
+  expectedResponseType?: 'ok-issue' | 'numeric' | 'level' | 'text';
+  /** A1 — unit for a numeric response, e.g. 'psi', 'L', '%'. Optional. */
+  unit?: string;
+  /** A1 — optional phrasing nudge for the agent when prompting this item. */
+  promptHint?: string;
 }
 
 /**

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -289,10 +289,17 @@ Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision 
   history; list hides retired unless `?includeInactive=true`). Also added a reusable
   mock-`TableClient` test harness that now covers **both** appliance Table twins
   (~92%, previously ~8%), lifting overall backend coverage. 17 new tests (731 pass);
-  `api_register.json` → v1.11.0. *Remaining increments:* the `Appliance`/`ChecklistItem`
-  extensions (`quirksNotes`, `zoneId`/`equipmentId`/`expectedResponseType`), the
-  per-`vehicleType` starter zone-vocabulary seed, and the admin authoring UI.
-  Ships standalone value (no AI).
+  `api_register.json` → v1.11.0.
+  *Increment 3 done 2026-06-23:* `ChecklistItem` gained the zone/equipment **link**
+  fields — `zoneId`, `equipmentId`, `expectedResponseType` (`ok-issue`|`numeric`|`level`|`text`),
+  `unit`, `promptHint`. Additive/optional and back-compatible; they round-trip through
+  both checklist paths (a brigade's per-appliance custom overlay and a `VehicleType`'s
+  locked standard items — both spread item fields and the Table twin stores them as JSON,
+  so no persistence changes were needed). This is the bridge that lets a checklist item
+  reference a physical zone/equipment piece for the agent walk-around. 2 round-trip tests
+  (733 pass). *Remaining increments:* the `Appliance` extensions (`variant`,
+  `inServiceDate`, `quirksNotes` — agent context), the per-`vehicleType` starter
+  zone-vocabulary seed, and the admin authoring UI. Ships standalone value (no AI).
 - **A3 — Phase 2: voice agent (cloud)** ⬜ — PWA voice mode → agent tool-use loop
   (`get_appliance_context`/`record_result`/`flag_issue`/`next_unchecked_in_zone`/
   `complete_run`) → `CheckRun` + `AgentSession`/`AgentTurn` transcript; read-back/confirm;
@@ -2884,6 +2891,7 @@ curl -H "Origin: https://malicious-site.com" \
 | 4.8 | Jun 2026 | AAR P1 (`?demo` deep link) | `/aar/?demo` loads the bundled example review straight onto the findings board (shareable walkthrough link); `main.js` strips the query after loading, fails open if the example can't be fetched, and reuses the home view's `loadExampleSession()` loader. Only print-stylesheet refinements remain in P1. |
 | 4.9 | Jun 2026 | A1 inc 1 (appliance zones) | First slice of the AI maintenance-agent truck model: `ApplianceZone` per-truck spatial entity end-to-end on the backend — types, in-memory DB + Table Storage twin (partition by applianceId) + factory, and admin-gated CRUD routes on the truck-checks router. Walk-around `order` + canonical `zoneCode` slug. 15 tests; `api_register.json` → v1.10.0. Remaining A1: ApplianceEquipment, Appliance/ChecklistItem extensions, zone-vocabulary seed, admin UI. |
 | 4.10 | Jun 2026 | A1 inc 2 (appliance equipment) | `ApplianceEquipment` per-truck inventory end-to-end (type, in-memory DB + Table Storage twin + factory, admin-gated CRUD `…/appliances/:id/equipment` + `…/equipment/:id`), with optional `zoneId`, `equipmentCode` slug, and an `active` retire flag (`?includeInactive`). Added a reusable mock-`TableClient` test harness covering both appliance Table twins (~8% → ~92%). 17 new tests; `api_register.json` → v1.11.0. |
+| 4.11 | Jun 2026 | A1 inc 3 (checklist links) | `ChecklistItem` gained the zone/equipment link fields (`zoneId`, `equipmentId`, `expectedResponseType`, `unit`, `promptHint`) — additive/optional, round-tripping through both the per-appliance custom overlay and `VehicleType` standard items with no persistence changes (items are spread + stored as JSON). The bridge that lets a checklist item reference a physical zone/equipment piece. 2 round-trip tests; 733 pass. |
 
 ---
 


### PR DESCRIPTION
## Summary

Third slice of **A1 — AI maintenance-agent truck model**: the **`ChecklistItem` zone/equipment link** — the bridge that makes the per-truck spatial model (#598/#599) actually useful. A checklist item can now reference a physical zone/equipment piece and describe the shape of its expected answer, so the future agent can group a check by area, walk it in zone order, and parse readings.

## What shipped
`ChecklistItem` gains optional, back-compatible fields (per `AI_MAINTENANCE_AGENT_DESIGN.md §4.4`):
- `zoneId` → link to an `ApplianceZone` (richer than the flat `section` string)
- `equipmentId` → item checks a specific `ApplianceEquipment` piece
- `expectedResponseType` — `'ok-issue'` (default pass/fail) | `'numeric'` | `'level'` | `'text'`
- `unit` — for numeric readings (`psi`, `L`, `%`)
- `promptHint` — phrasing nudge for the agent

## No persistence changes
The fields round-trip through **both** checklist paths with zero storage code:
- a brigade's **per-appliance custom overlay** (the template route spreads item fields; the Table twin stores items as `JSON.stringify`/`JSON.parse`)
- a **`VehicleType`'s locked standard items** (`normaliseStandardItems` spreads `...item`)

## Tests / verification
2 round-trip tests prove preservation through (a) custom-overlay save → effective checklist, and (b) vehicle-type create → list (confirming `normaliseStandardItems` keeps the extras while still forcing `id`/`order`/`itemCode`/`isStandard`). Typecheck clean; full suite **733 pass**; coverage **green**. Type-only change + tests — no new endpoints, so `api_register.json` is unchanged.

## Remaining A1 increments
`Appliance` extensions (`variant`, `inServiceDate`, `quirksNotes` — free-text agent context) · per-`vehicleType` starter zone-vocabulary seed · admin authoring UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_