### PR TITLE
feat(truck-check): Appliance agent-context fields (A1 inc 4)

### DIFF
--- a/backend/src/__tests__/applianceQuirks.test.ts
+++ b/backend/src/__tests__/applianceQuirks.test.ts
@@ -1,0 +1,67 @@
+/**
+ * A1 inc 4 — Appliance agent-context fields (variant, inServiceDate, quirksNotes).
+ *
+ * Free-text brigade knowledge + build details the maintenance agent uses for
+ * age/nuance. Additive; must round-trip through create and update.
+ */
+
+jest.mock('../index');
+
+import request from 'supertest';
+import express, { Express } from 'express';
+import truckChecksRouter from '../routes/truckChecks';
+
+let app: Express;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.set('io', { emit: jest.fn(), to: jest.fn().mockReturnThis() });
+  app.use('/api/truck-checks', truckChecksRouter);
+});
+
+describe('Appliance agent-context fields', () => {
+  it('persists variant/inServiceDate/quirksNotes on create and returns them on read', async () => {
+    const created = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({
+        name: 'Quirks Truck',
+        variant: 'Isuzu FTS (BTM body)',
+        inServiceDate: '2012-03-01',
+        quirksNotes: 'Hatch sticks in cold; secondary pump primes slowly.',
+      })
+      .expect(201);
+
+    expect(created.body.variant).toBe('Isuzu FTS (BTM body)');
+    expect(created.body.inServiceDate).toBe('2012-03-01');
+    expect(created.body.quirksNotes).toMatch(/primes slowly/);
+
+    const read = await request(app)
+      .get(`/api/truck-checks/appliances/${created.body.id}`).expect(200);
+    expect(read.body.variant).toBe('Isuzu FTS (BTM body)');
+    expect(read.body.quirksNotes).toMatch(/Hatch sticks/);
+  });
+
+  it('updates the agent-context fields', async () => {
+    const created = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Quirks Truck 2' }).expect(201);
+    expect(created.body.quirksNotes).toBeUndefined();
+
+    const updated = await request(app)
+      .put(`/api/truck-checks/appliances/${created.body.id}`)
+      .send({ name: 'Quirks Truck 2', quirksNotes: 'Tank gauge reads 10% high.', variant: 'Hino' })
+      .expect(200);
+
+    expect(updated.body.quirksNotes).toBe('Tank gauge reads 10% high.');
+    expect(updated.body.variant).toBe('Hino');
+  });
+
+  it('ignores non-string agent-context values', async () => {
+    const created = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Quirks Truck 3', quirksNotes: 12345, variant: { x: 1 } }).expect(201);
+    expect(created.body.quirksNotes).toBeUndefined();
+    expect(created.body.variant).toBeUndefined();
+  });
+});

--- a/backend/src/routes/truckChecks.ts
+++ b/backend/src/routes/truckChecks.ts
@@ -231,6 +231,9 @@ function extractApplianceDetails(body: Record<string, unknown>) {
     make: typeof body.make === 'string' ? body.make : undefined,
     model: typeof body.model === 'string' ? body.model : undefined,
     year: Number.isFinite(yearNum) ? yearNum : undefined,
+    variant: typeof body.variant === 'string' ? body.variant : undefined,
+    inServiceDate: typeof body.inServiceDate === 'string' ? body.inServiceDate : undefined,
+    quirksNotes: typeof body.quirksNotes === 'string' ? body.quirksNotes : undefined,
   };
 }
 

--- a/backend/src/services/tableStorageTruckChecksDatabase.ts
+++ b/backend/src/services/tableStorageTruckChecksDatabase.ts
@@ -207,6 +207,9 @@ export class TableStorageTruckChecksDatabase implements ITruckChecksDatabase {
       make: details?.make,
       model: details?.model,
       year: details?.year,
+      variant: details?.variant,
+      inServiceDate: details?.inServiceDate,
+      quirksNotes: details?.quirksNotes,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -226,6 +229,9 @@ export class TableStorageTruckChecksDatabase implements ITruckChecksDatabase {
       make: appliance.make || '',
       model: appliance.model || '',
       year: appliance.year ?? 0,
+      variant: appliance.variant || '',
+      inServiceDate: appliance.inServiceDate || '',
+      quirksNotes: appliance.quirksNotes || '',
       createdAt: appliance.createdAt.toISOString(),
       updatedAt: appliance.updatedAt.toISOString(),
     };
@@ -250,6 +256,9 @@ export class TableStorageTruckChecksDatabase implements ITruckChecksDatabase {
         entity.make = details.make || '';
         entity.model = details.model || '';
         entity.year = details.year ?? 0;
+        entity.variant = details.variant || '';
+        entity.inServiceDate = details.inServiceDate || '';
+        entity.quirksNotes = details.quirksNotes || '';
       }
       entity.updatedAt = new Date().toISOString();
 
@@ -287,6 +296,9 @@ export class TableStorageTruckChecksDatabase implements ITruckChecksDatabase {
       make: (entity.make as string) || undefined,
       model: (entity.model as string) || undefined,
       year: (entity.year as number) || undefined,
+      variant: (entity.variant as string) || undefined,
+      inServiceDate: (entity.inServiceDate as string) || undefined,
+      quirksNotes: (entity.quirksNotes as string) || undefined,
       createdAt: new Date(entity.createdAt as string),
       updatedAt: new Date(entity.updatedAt as string),
     };

--- a/backend/src/services/truckChecksDatabase.ts
+++ b/backend/src/services/truckChecksDatabase.ts
@@ -141,6 +141,9 @@ class TruckChecksDatabase {
       make: details?.make,
       model: details?.model,
       year: details?.year,
+      variant: details?.variant,
+      inServiceDate: details?.inServiceDate,
+      quirksNotes: details?.quirksNotes,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -172,6 +175,9 @@ class TruckChecksDatabase {
         appliance.make = details.make;
         appliance.model = details.model;
         appliance.year = details.year;
+        appliance.variant = details.variant;
+        appliance.inServiceDate = details.inServiceDate;
+        appliance.quirksNotes = details.quirksNotes;
       }
       appliance.updatedAt = new Date();
       return appliance;

--- a/backend/src/services/truckChecksDbFactory.ts
+++ b/backend/src/services/truckChecksDbFactory.ts
@@ -35,6 +35,9 @@ export interface ApplianceDetails {
   make?: string;
   model?: string;
   year?: number;
+  variant?: string;
+  inServiceDate?: string;
+  quirksNotes?: string;
 }
 
 // Interface shared by truck checks database implementations

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -375,6 +375,11 @@ export interface Appliance {
   make?: string;                 // manufacturer, e.g. 'Isuzu'
   model?: string;                // model, e.g. 'FTS 800'
   year?: number;                 // build/registration year
+  // ─── A1 agent context (all optional) ───
+  variant?: string;              // build/body variant, e.g. 'Isuzu FTS', 'BTM body'
+  inServiceDate?: string;        // ISO date the appliance entered service (age nuance)
+  quirksNotes?: string;          // free-text brigade knowledge fed to the agent,
+                                 // e.g. 'hatch sticks in cold', 'secondary pump primes slowly'
   createdAt: Date;
   updatedAt: Date;
 }

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -297,9 +297,15 @@ Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision 
   locked standard items — both spread item fields and the Table twin stores them as JSON,
   so no persistence changes were needed). This is the bridge that lets a checklist item
   reference a physical zone/equipment piece for the agent walk-around. 2 round-trip tests
-  (733 pass). *Remaining increments:* the `Appliance` extensions (`variant`,
-  `inServiceDate`, `quirksNotes` — agent context), the per-`vehicleType` starter
-  zone-vocabulary seed, and the admin authoring UI. Ships standalone value (no AI).
+  (733 pass).
+  *Increment 4 done 2026-06-23:* `Appliance` gained the agent-context fields `variant`,
+  `inServiceDate`, and `quirksNotes` (free-text brigade knowledge fed to the LLM —
+  "hatch sticks in cold", "secondary pump primes slowly"). Wired through
+  `extractApplianceDetails` (string-validated) → `ApplianceDetails` → `createAppliance`/
+  `updateAppliance` in **both** DB twins (in-memory + Table Storage entity columns).
+  3 round-trip tests (736 pass). *Remaining increments:* the per-`vehicleType` starter
+  zone-vocabulary seed, and the admin authoring UI (the first user-facing surface).
+  Ships standalone value (no AI).
 - **A3 — Phase 2: voice agent (cloud)** ⬜ — PWA voice mode → agent tool-use loop
   (`get_appliance_context`/`record_result`/`flag_issue`/`next_unchecked_in_zone`/
   `complete_run`) → `CheckRun` + `AgentSession`/`AgentTurn` transcript; read-back/confirm;
@@ -2892,6 +2898,7 @@ curl -H "Origin: https://malicious-site.com" \
 | 4.9 | Jun 2026 | A1 inc 1 (appliance zones) | First slice of the AI maintenance-agent truck model: `ApplianceZone` per-truck spatial entity end-to-end on the backend — types, in-memory DB + Table Storage twin (partition by applianceId) + factory, and admin-gated CRUD routes on the truck-checks router. Walk-around `order` + canonical `zoneCode` slug. 15 tests; `api_register.json` → v1.10.0. Remaining A1: ApplianceEquipment, Appliance/ChecklistItem extensions, zone-vocabulary seed, admin UI. |
 | 4.10 | Jun 2026 | A1 inc 2 (appliance equipment) | `ApplianceEquipment` per-truck inventory end-to-end (type, in-memory DB + Table Storage twin + factory, admin-gated CRUD `…/appliances/:id/equipment` + `…/equipment/:id`), with optional `zoneId`, `equipmentCode` slug, and an `active` retire flag (`?includeInactive`). Added a reusable mock-`TableClient` test harness covering both appliance Table twins (~8% → ~92%). 17 new tests; `api_register.json` → v1.11.0. |
 | 4.11 | Jun 2026 | A1 inc 3 (checklist links) | `ChecklistItem` gained the zone/equipment link fields (`zoneId`, `equipmentId`, `expectedResponseType`, `unit`, `promptHint`) — additive/optional, round-tripping through both the per-appliance custom overlay and `VehicleType` standard items with no persistence changes (items are spread + stored as JSON). The bridge that lets a checklist item reference a physical zone/equipment piece. 2 round-trip tests; 733 pass. |
+| 4.12 | Jun 2026 | A1 inc 4 (appliance agent context) | `Appliance` gained `variant`, `inServiceDate`, `quirksNotes` (free-text brigade knowledge for the agent), wired through `extractApplianceDetails` + `ApplianceDetails` + create/update in both DB twins (in-memory + Table Storage columns). 3 round-trip tests; 736 pass. |
 
 ---
 


### PR DESCRIPTION
## Summary

Fourth slice of **A1**: `Appliance` agent-context fields. Captures the build/age details and free-text brigade knowledge the maintenance agent will feed to the LLM for nuance — *"hatch sticks in cold"*, *"secondary pump primes slowly"*.

## What shipped
`Appliance` gains three optional fields (per `AI_MAINTENANCE_AGENT_DESIGN.md §4.3`):
- `variant` — build/body variant (e.g. `'Isuzu FTS (BTM body)'`)
- `inServiceDate` — ISO date the truck entered service (age nuance)
- `quirksNotes` — free-text brigade knowledge for the agent

Wired end-to-end through the existing appliance create/update path:
- `extractApplianceDetails` (string-validated — non-string input is ignored)
- `ApplianceDetails` interface
- `createAppliance`/`updateAppliance` in **both** DB twins (in-memory + Table Storage entity columns + `entityToAppliance` read-back)

## Tests / verification
3 round-trip tests (create→read, update, non-string rejection). Full backend suite **736 pass**; coverage **green**; build emits. **No new endpoints** — the fields flow through the existing appliance `POST`/`PUT`, so `api_register.json` is unchanged.

## Remaining A1 increments
Per-`vehicleType` starter **zone-vocabulary seed** (a code-level taxonomy, like `checklistVocabulary.ts`, to seed a new truck's zones) · **admin authoring UI** (the first user-facing surface — best paired with a browser for screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_