### PR TITLE
feat(truck-check): per-vehicleType starter zone-vocabulary seed (A1 inc 5)

### DIFF
--- a/backend/src/__tests__/applianceZoneSeed.test.ts
+++ b/backend/src/__tests__/applianceZoneSeed.test.ts
@@ -1,0 +1,261 @@
+/**
+ * A1 inc 5 — Per-vehicleType starter zone-vocabulary seed.
+ *
+ * Tests:
+ *  - getStarterZones() unit tests (pure function, no HTTP)
+ *  - POST /appliances auto-seeds zones when vehicleTypeId is given
+ *  - POST /appliances/:id/seed-zones happy path, idempotency, replace=true, 422s
+ */
+
+jest.mock('../index');
+
+import request from 'supertest';
+import express, { Express } from 'express';
+import jwt from 'jsonwebtoken';
+import truckChecksRouter from '../routes/truckChecks';
+import { getStarterZones, ZONE_VOCABULARY } from '../constants/zoneVocabulary';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-in-production';
+const adminToken = () =>
+  jwt.sign({ userId: 'admin-1', username: 'admin', role: 'admin', organizationId: 'org-1' }, JWT_SECRET);
+const auth = () => ({ Authorization: `Bearer ${adminToken()}` });
+
+let app: Express;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.set('io', { emit: jest.fn(), to: jest.fn().mockReturnThis() });
+  app.use('/api/truck-checks', truckChecksRouter);
+});
+
+// ─── Unit: vocabulary helper ──────────────────────────────────────────────────
+
+describe('getStarterZones()', () => {
+  it('returns zones for cat1-tanker', () => {
+    const zones = getStarterZones('cat1-tanker');
+    expect(zones.length).toBeGreaterThan(0);
+    const codes = zones.map((z) => z.zoneCode);
+    expect(codes).toContain('cab');
+    expect(codes).toContain('pump-panel');
+    expect(codes).toContain('rear');
+  });
+
+  it('cat1 alias returns the same layout as cat1-tanker', () => {
+    expect(getStarterZones('cat1')).toBe(getStarterZones('cat1-tanker'));
+  });
+
+  it('returns zones for pumper', () => {
+    const zones = getStarterZones('pumper');
+    const codes = zones.map((z) => z.zoneCode);
+    expect(codes).toContain('pump-panel');
+    expect(codes).toContain('compt-driver-front');
+    expect(codes).toContain('compt-passenger-rear');
+  });
+
+  it('returns zones for bulk-water-tender', () => {
+    const zones = getStarterZones('bulk-water-tender');
+    expect(zones.map((z) => z.zoneCode)).toContain('tank-top');
+  });
+
+  it('returns zones for rescue-tender', () => {
+    const zones = getStarterZones('rescue-tender');
+    expect(zones.map((z) => z.zoneCode)).toContain('compt-driver');
+  });
+
+  it('returns zones for command', () => {
+    const zones = getStarterZones('command');
+    expect(zones.map((z) => z.zoneCode)).toContain('cab');
+    expect(zones.length).toBeLessThan(5);
+  });
+
+  it('returns empty array for unknown code', () => {
+    expect(getStarterZones('unknown-type-xyz')).toEqual([]);
+  });
+
+  it('all entries in ZONE_VOCABULARY have unique zoneCode per array', () => {
+    for (const [code, specs] of Object.entries(ZONE_VOCABULARY)) {
+      const seen = new Set(specs.map((s) => s.zoneCode));
+      expect(seen.size).toBe(specs.length);
+      // each spec must have a non-empty zoneCode
+      for (const s of specs) {
+        expect(s.zoneCode).toBeTruthy();
+        expect(typeof s.name).toBe('string');
+      }
+      void code; // suppress unused var lint
+    }
+  });
+
+  it('zones are in ascending order', () => {
+    const zones = getStarterZones('cat1-tanker');
+    for (let i = 1; i < zones.length; i++) {
+      expect(zones[i].order).toBeGreaterThan(zones[i - 1].order);
+    }
+  });
+});
+
+// ─── Integration: auto-seed on appliance create ───────────────────────────────
+
+describe('Auto-seed zones on appliance create', () => {
+  it('seeds zones when vehicleTypeId matches a known type code', async () => {
+    // Create a vehicle type with a known vocabulary code
+    const vtRes = await request(app)
+      .post('/api/truck-checks/vehicle-types')
+      .set(auth())
+      .send({ name: 'Cat 1 Tanker', code: 'cat1-tanker', isStandard: false, standardItems: [] })
+      .expect(201);
+    const vehicleTypeId = vtRes.body.id;
+
+    // Create appliance linked to it
+    const appRes = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Seed Test Tanker', vehicleTypeId })
+      .expect(201);
+    const applianceId = appRes.body.id;
+
+    // Zones should have been auto-seeded
+    const zonesRes = await request(app)
+      .get(`/api/truck-checks/appliances/${applianceId}/zones`)
+      .set(auth())
+      .expect(200);
+
+    const codes = (zonesRes.body as { zoneCode: string }[]).map((z) => z.zoneCode);
+    expect(codes).toContain('cab');
+    expect(codes).toContain('pump-panel');
+    expect(codes).toContain('rear');
+    expect(zonesRes.body).toHaveLength(getStarterZones('cat1-tanker').length);
+  });
+
+  it('does not seed zones when vehicleTypeId is absent', async () => {
+    const appRes = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'No-Type Truck' })
+      .expect(201);
+
+    const zonesRes = await request(app)
+      .get(`/api/truck-checks/appliances/${appRes.body.id}/zones`)
+      .set(auth())
+      .expect(200);
+
+    expect(zonesRes.body).toHaveLength(0);
+  });
+
+  it('does not fail create when vehicleTypeId points to an unknown vehicle type', async () => {
+    const appRes = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Ghost Type Truck', vehicleTypeId: 'does-not-exist' })
+      .expect(201); // must succeed
+
+    // No zones seeded
+    const zonesRes = await request(app)
+      .get(`/api/truck-checks/appliances/${appRes.body.id}/zones`)
+      .set(auth())
+      .expect(200);
+    expect(zonesRes.body).toHaveLength(0);
+  });
+});
+
+// ─── Integration: POST seed-zones endpoint ────────────────────────────────────
+
+describe('POST /appliances/:id/seed-zones', () => {
+  let applianceWithTypeId: string;
+  let applianceNoTypeId: string;
+
+  beforeAll(async () => {
+    // Vehicle type whose code is in the vocabulary
+    const vtRes = await request(app)
+      .post('/api/truck-checks/vehicle-types')
+      .set(auth())
+      .send({ name: 'Pumper (seed test)', code: 'pumper', isStandard: false, standardItems: [] })
+      .expect(201);
+
+    // Appliance WITHOUT vehicleTypeId (create first to skip auto-seed)
+    const noType = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Seed-Zones No-Type' })
+      .expect(201);
+    applianceNoTypeId = noType.body.id;
+
+    // Appliance WITH vehicleTypeId — but we'll create a separate one for the
+    // seed-zones tests so the auto-seeded one doesn't interfere.
+    const withType = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Seed-Zones Pumper', vehicleTypeId: vtRes.body.id })
+      .expect(201);
+    applianceWithTypeId = withType.body.id;
+  });
+
+  it('401 when unauthenticated', async () => {
+    await request(app)
+      .post(`/api/truck-checks/appliances/${applianceWithTypeId}/seed-zones`)
+      .expect(401);
+  });
+
+  it('404 for unknown appliance', async () => {
+    await request(app)
+      .post('/api/truck-checks/appliances/no-such-id/seed-zones')
+      .set(auth())
+      .expect(404);
+  });
+
+  it('422 when appliance has no vehicleTypeId', async () => {
+    const res = await request(app)
+      .post(`/api/truck-checks/appliances/${applianceNoTypeId}/seed-zones`)
+      .set(auth())
+      .expect(422);
+    expect(res.body.error).toMatch(/vehicleTypeId/);
+  });
+
+  it('is idempotent — returns existing zones without re-seeding', async () => {
+    // auto-seed already happened on create; call seed-zones again
+    const res = await request(app)
+      .post(`/api/truck-checks/appliances/${applianceWithTypeId}/seed-zones`)
+      .set(auth())
+      .expect(200);
+
+    expect(res.body.seeded).toBe(0);
+    expect(res.body.message).toMatch(/already exist/);
+    expect(res.body.zones.length).toBeGreaterThan(0);
+  });
+
+  it('re-seeds when ?replace=true', async () => {
+    const expectedCount = getStarterZones('pumper').length;
+
+    const res = await request(app)
+      .post(`/api/truck-checks/appliances/${applianceWithTypeId}/seed-zones?replace=true`)
+      .set(auth())
+      .expect(200);
+
+    expect(res.body.seeded).toBe(expectedCount);
+    expect(res.body.zones).toHaveLength(expectedCount);
+
+    // After replace, zones list must match the expected count
+    const list = await request(app)
+      .get(`/api/truck-checks/appliances/${applianceWithTypeId}/zones`)
+      .set(auth())
+      .expect(200);
+    expect(list.body).toHaveLength(expectedCount);
+  });
+
+  it('returns seeded=0 and a message for an unknown vehicle type code', async () => {
+    // Create a vehicle type whose code is NOT in the vocabulary
+    const vtRes = await request(app)
+      .post('/api/truck-checks/vehicle-types')
+      .set(auth())
+      .send({ name: 'Custom Type', code: 'brigade-custom-xyz', isStandard: false, standardItems: [] })
+      .expect(201);
+
+    const appRes = await request(app)
+      .post('/api/truck-checks/appliances')
+      .send({ name: 'Custom Type Truck', vehicleTypeId: vtRes.body.id })
+      .expect(201);
+
+    const res = await request(app)
+      .post(`/api/truck-checks/appliances/${appRes.body.id}/seed-zones`)
+      .set(auth())
+      .expect(200);
+
+    expect(res.body.seeded).toBe(0);
+    expect(res.body.message).toMatch(/brigade-custom-xyz/);
+  });
+});

--- a/backend/src/constants/zoneVocabulary.ts
+++ b/backend/src/constants/zoneVocabulary.ts
@@ -1,0 +1,122 @@
+/**
+ * A1 — Per-vehicleType starter zone vocabulary.
+ *
+ * A code-level taxonomy of canonical zone specs keyed by VehicleType.code.
+ * Seeded onto a new appliance when it is first assigned a vehicleTypeId;
+ * brigades then edit, add, or remove zones to match the actual vehicle.
+ *
+ * Zone order increments by 10 to leave room for brigade insertions.
+ * ZoneCodes are stable slugs used for cross-brigade analytics — don't rename.
+ *
+ * Modelled on NSW RFS standard appliance layouts.  Where two type codes share
+ * a layout they point at the same spec array (same reference, no duplication).
+ */
+
+import type { ApplianceZoneSide } from '../types';
+
+export interface ZoneSpec {
+  name: string;
+  zoneCode: string;
+  side?: ApplianceZoneSide;
+  description?: string;
+  order: number;
+}
+
+// ── Layout definitions ────────────────────────────────────────────────────────
+
+const cat1Tanker: ZoneSpec[] = [
+  { order: 0,  name: 'Cab',                   zoneCode: 'cab',               side: 'interior',  description: 'Driver and passenger cab compartment' },
+  { order: 10, name: 'Pump Panel',             zoneCode: 'pump-panel',        side: 'driver',    description: 'Main pump controls and gauges' },
+  { order: 20, name: 'Driver-side Lockers',    zoneCode: 'lockers-driver',    side: 'driver',    description: 'Storage lockers on the driver side' },
+  { order: 30, name: 'Rear',                   zoneCode: 'rear',              side: 'rear',      description: 'Rear of the vehicle — hose reel, tow hitch, rear lights' },
+  { order: 40, name: 'Passenger-side Lockers', zoneCode: 'lockers-passenger', side: 'passenger', description: 'Storage lockers on the passenger side' },
+  { order: 50, name: 'Roof',                   zoneCode: 'roof',              side: 'top',       description: 'Roof-mounted equipment and ladder' },
+  { order: 60, name: 'Underbody',              zoneCode: 'underbody',         side: 'na',        description: 'Ground-level checks — tyres, prop shafts, low-mounted fittings' },
+];
+
+const heavyTanker: ZoneSpec[] = [
+  { order: 0,  name: 'Cab',                   zoneCode: 'cab',               side: 'interior',  description: 'Driver and crew cab' },
+  { order: 10, name: 'Pump Panel',             zoneCode: 'pump-panel',        side: 'driver',    description: 'High-capacity pump controls and gauges' },
+  { order: 20, name: 'Driver-side Lockers',    zoneCode: 'lockers-driver',    side: 'driver',    description: 'Large driver-side storage lockers' },
+  { order: 30, name: 'Rear',                   zoneCode: 'rear',              side: 'rear',      description: 'Rear hose loads, monitor, tow hitch' },
+  { order: 40, name: 'Passenger-side Lockers', zoneCode: 'lockers-passenger', side: 'passenger', description: 'Large passenger-side storage lockers' },
+  { order: 50, name: 'Roof',                   zoneCode: 'roof',              side: 'top',       description: 'Roof-mounted hose, ladders, water monitor' },
+  { order: 60, name: 'Underbody',              zoneCode: 'underbody',         side: 'na',        description: 'Tyres, prop shafts, low-mounted fittings' },
+];
+
+const pumper: ZoneSpec[] = [
+  { order: 0,  name: 'Cab',                              zoneCode: 'cab',                     side: 'interior',  description: 'Driver and crew cab compartment' },
+  { order: 10, name: 'Driver-side Front Compartments',   zoneCode: 'compt-driver-front',      side: 'driver',    description: 'Forward driver-side lockers (D1 area)' },
+  { order: 20, name: 'Driver-side Rear Compartments',    zoneCode: 'compt-driver-rear',       side: 'driver',    description: 'Rearward driver-side lockers (D2 area)' },
+  { order: 30, name: 'Pump Panel',                       zoneCode: 'pump-panel',              side: 'driver',    description: 'Main pump controls and gauges' },
+  { order: 40, name: 'Rear',                             zoneCode: 'rear',                    side: 'rear',      description: 'Rear hose loads, lighting, tow hitch' },
+  { order: 50, name: 'Passenger-side Rear Compartments', zoneCode: 'compt-passenger-rear',    side: 'passenger', description: 'Rearward passenger-side lockers (P2 area)' },
+  { order: 60, name: 'Passenger-side Front Compartments', zoneCode: 'compt-passenger-front', side: 'passenger', description: 'Forward passenger-side lockers (P1 area)' },
+  { order: 70, name: 'Roof / Aerial',                    zoneCode: 'roof',                    side: 'top',       description: 'Roof-mounted equipment, ladders, or aerial' },
+  { order: 80, name: 'Underbody',                        zoneCode: 'underbody',               side: 'na',        description: 'Ground-level checks — tyres, stabilisers, low fittings' },
+];
+
+const bulkWaterTender: ZoneSpec[] = [
+  { order: 0,  name: 'Cab',              zoneCode: 'cab',            side: 'interior',  description: 'Driver cab compartment' },
+  { order: 10, name: 'Driver-side',      zoneCode: 'side-driver',    side: 'driver',    description: 'Driver-side access points and fittings' },
+  { order: 20, name: 'Rear',             zoneCode: 'rear',           side: 'rear',      description: 'Rear discharge points, hose connections, tow hitch' },
+  { order: 30, name: 'Passenger-side',   zoneCode: 'side-passenger', side: 'passenger', description: 'Passenger-side access points and fittings' },
+  { order: 40, name: 'Tank Top',         zoneCode: 'tank-top',       side: 'top',       description: 'Tank hatches, fill points, and roof-level fittings' },
+  { order: 50, name: 'Underbody',        zoneCode: 'underbody',      side: 'na',        description: 'Tyres, chassis, stabilisers' },
+];
+
+const rescueTender: ZoneSpec[] = [
+  { order: 0,  name: 'Cab',                          zoneCode: 'cab',             side: 'interior',  description: 'Driver and crew cab' },
+  { order: 10, name: 'Driver-side Compartments',     zoneCode: 'compt-driver',    side: 'driver',    description: 'Driver-side rescue equipment compartments' },
+  { order: 20, name: 'Rear',                         zoneCode: 'rear',            side: 'rear',      description: 'Rear load area, lighting bar, hitch' },
+  { order: 30, name: 'Passenger-side Compartments',  zoneCode: 'compt-passenger', side: 'passenger', description: 'Passenger-side rescue equipment compartments' },
+  { order: 40, name: 'Roof',                         zoneCode: 'roof',            side: 'top',       description: 'Roof-mounted light bars and equipment' },
+  { order: 50, name: 'Underbody',                    zoneCode: 'underbody',       side: 'na',        description: 'Tyres, prop shafts, low-mounted hydraulics' },
+];
+
+const commandSupport: ZoneSpec[] = [
+  { order: 0,  name: 'Cab',        zoneCode: 'cab',  side: 'interior', description: 'Vehicle cab and rear passenger area' },
+  { order: 10, name: 'Boot / Rear', zoneCode: 'rear', side: 'rear',     description: 'Boot space, command equipment, cabling' },
+];
+
+// ── Vocabulary registry ───────────────────────────────────────────────────────
+
+/**
+ * Starter zone taxonomy keyed by `VehicleType.code`.  Multiple codes may share
+ * the same layout (aliases point at the same array).
+ */
+export const ZONE_VOCABULARY: Record<string, ZoneSpec[]> = {
+  // Category tankers
+  'cat1-tanker': cat1Tanker,
+  'cat1':        cat1Tanker,
+  // Cat 2 shares the heavy-tanker layout
+  'cat2-tanker': heavyTanker,
+  'cat2':        heavyTanker,
+  // Cat 3 / heavy tanker
+  'cat3-tanker': heavyTanker,
+  'cat3':        heavyTanker,
+  'heavy-tanker': heavyTanker,
+  // Urban pumper / pumping tender
+  'pumper':         pumper,
+  'pumping-tender': pumper,
+  'urban-pumper':   pumper,
+  // Bulk water tender
+  'bulk-water-tender': bulkWaterTender,
+  'bwt':               bulkWaterTender,
+  // Rescue tender
+  'rescue-tender': rescueTender,
+  'rescue':        rescueTender,
+  // Command / support / liaison
+  'command-support': commandSupport,
+  'command':         commandSupport,
+  'support':         commandSupport,
+  'liaison':         commandSupport,
+};
+
+/**
+ * Returns the starter zone specs for a vehicle type code, or an empty array
+ * when no vocabulary entry exists for that code.
+ */
+export function getStarterZones(vehicleTypeCode: string): ZoneSpec[] {
+  return ZONE_VOCABULARY[vehicleTypeCode] ?? [];
+}

--- a/backend/src/routes/truckChecks.ts
+++ b/backend/src/routes/truckChecks.ts
@@ -28,6 +28,7 @@ import { azureStorageService } from '../services/azureStorage';
 import { authMiddleware, requireAdmin } from '../middleware/auth';
 import { attachOrganization } from '../middleware/entitlements';
 import { slugify } from '../utils/slug';
+import { getStarterZones } from '../constants/zoneVocabulary';
 import { io } from '../index';
 import {
   validateCreateAppliance,
@@ -121,7 +122,31 @@ router.post('/appliances', enforceVehicleLimit(), validateCreateAppliance, handl
     }
 
     const db = await ensureTruckChecksDatabase(req.isDemoMode);
-    const appliance = await db.createAppliance(name, description, photoUrl, stationId, vehicleType, extractApplianceDetails(req.body));
+    const details = extractApplianceDetails(req.body);
+    const appliance = await db.createAppliance(name, description, photoUrl, stationId, vehicleType, details);
+
+    // Auto-seed zones from the starter vocabulary when a vehicleTypeId is provided.
+    if (details.vehicleTypeId) {
+      try {
+        const vt = await ensureVehicleTypeDatabase().getById(details.vehicleTypeId);
+        if (vt) {
+          const specs = getStarterZones(vt.code);
+          const zoneDb = ensureApplianceZoneDatabase();
+          await Promise.all(specs.map((s) => zoneDb.create({
+            applianceId: appliance.id,
+            stationId: appliance.stationId,
+            name: s.name,
+            zoneCode: s.zoneCode,
+            side: s.side,
+            order: s.order,
+            description: s.description,
+          })));
+        }
+      } catch (seedErr) {
+        logger.warn('Zone auto-seed failed (non-fatal):', seedErr);
+      }
+    }
+
     res.status(201).json(appliance);
   } catch (error) {
     logger.error('Error creating appliance:', error);
@@ -169,6 +194,62 @@ router.delete('/appliances/:id', validateApplianceId, handleValidationErrors, as
   } catch (error) {
     logger.error('Error deleting appliance:', error);
     res.status(500).json({ error: 'Failed to delete appliance' });
+  }
+});
+
+/**
+ * POST /api/truck-checks/appliances/:id/seed-zones
+ * Seed an appliance's zones from the starter vocabulary for its vehicle type.
+ * Admin-only. Idempotent by default (no-op when zones already exist).
+ * Pass ?replace=true to delete existing zones and re-seed from scratch.
+ */
+router.post('/appliances/:id/seed-zones', authMiddleware, attachOrganization, requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const truckDb = await ensureTruckChecksDatabase(req.isDemoMode);
+    const appliance = await truckDb.getApplianceById(req.params.id);
+    if (!appliance) return res.status(404).json({ error: 'Appliance not found' });
+
+    if (!appliance.vehicleTypeId) {
+      return res.status(422).json({ error: 'Appliance has no vehicleTypeId — assign a vehicle type first' });
+    }
+
+    const vt = await ensureVehicleTypeDatabase().getById(appliance.vehicleTypeId);
+    if (!vt) {
+      return res.status(422).json({ error: 'Vehicle type not found' });
+    }
+
+    const specs = getStarterZones(vt.code);
+    if (!specs.length) {
+      return res.json({ seeded: 0, zones: [], message: `No starter vocabulary for vehicle type code "${vt.code}"` });
+    }
+
+    const zoneDb = ensureApplianceZoneDatabase();
+    const replace = req.query.replace === 'true';
+
+    if (!replace) {
+      const existing = await zoneDb.listForAppliance(appliance.id);
+      if (existing.length) {
+        return res.json({ seeded: 0, zones: existing, message: 'Zones already exist — pass ?replace=true to re-seed' });
+      }
+    } else {
+      const existing = await zoneDb.listForAppliance(appliance.id);
+      await Promise.all(existing.map((z) => zoneDb.delete(z.id)));
+    }
+
+    const zones = await Promise.all(specs.map((s) => zoneDb.create({
+      applianceId: appliance.id,
+      stationId: appliance.stationId,
+      name: s.name,
+      zoneCode: s.zoneCode,
+      side: s.side,
+      order: s.order,
+      description: s.description,
+    })));
+
+    res.json({ seeded: zones.length, zones });
+  } catch (error) {
+    logger.error('Error seeding appliance zones:', error);
+    res.status(500).json({ error: 'Failed to seed appliance zones' });
   }
 });
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -303,9 +303,15 @@ Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision 
   "hatch sticks in cold", "secondary pump primes slowly"). Wired through
   `extractApplianceDetails` (string-validated) → `ApplianceDetails` → `createAppliance`/
   `updateAppliance` in **both** DB twins (in-memory + Table Storage entity columns).
-  3 round-trip tests (736 pass). *Remaining increments:* the per-`vehicleType` starter
-  zone-vocabulary seed, and the admin authoring UI (the first user-facing surface).
-  Ships standalone value (no AI).
+  3 round-trip tests (736 pass).
+  *Increment 5 done 2026-06-23:* `backend/src/constants/zoneVocabulary.ts` — a
+  code-level taxonomy mapping `VehicleType.code` to canonical walk-around `ZoneSpec[]`
+  for standard NSW RFS appliance classes (Cat 1 tanker, heavy tanker, pumper, bulk water
+  tender, rescue tender, command/support). Zones auto-seed on `POST /appliances` when a
+  `vehicleTypeId` is supplied (non-fatal catch if seed fails). New admin endpoint
+  `POST /appliances/:id/seed-zones` supports explicit/idempotent seeding and
+  `?replace=true` re-seed. 18 new tests (754 pass); all coverage gates green.
+  *Remaining:* admin authoring UI (the first user-facing surface). Ships standalone value (no AI).
 - **A3 — Phase 2: voice agent (cloud)** ⬜ — PWA voice mode → agent tool-use loop
   (`get_appliance_context`/`record_result`/`flag_issue`/`next_unchecked_in_zone`/
   `complete_run`) → `CheckRun` + `AgentSession`/`AgentTurn` transcript; read-back/confirm;
@@ -460,7 +466,7 @@ is retained in the model but **unused/unenforced** (devices dropped from pricing
 - 2026-06-07: **Infrastructure-as-Code introduced (Issue #513).** Added `infra/` (Bicep) — the project's first IaC. Codifies the Table Storage data tier and provides a **dual-host comparison** (Linux B1 always-warm vs Azure Container Apps scale-to-zero) running the current Socket.io app unchanged, side-by-side with prod (prod untouched). Includes a multi-stage `Dockerfile`, a manual `infra-deploy.yml` workflow, and `infra/README.md`. **Critical finding:** the GitHub→Azure OIDC app registration was deleted from the tenant, silently breaking the last several `main` deploys (`AADSTS700016` at `Login to Azure`) — so the v1.1 merge did not reach production. The IaC README documents the one-time OIDC bootstrap that restores prod deploys. Real-time decision: **defer SignalR**; when multi-brigade scale needs a backplane, adopt **Azure Web PubSub for Socket.IO** (keeps the code, free tier) rather than a SignalR SDK rewrite. Follow-ups to raise: Windows→Linux prod migration, App Insights daily cap, managed-identity storage auth.
 - 2026-06-08: **SaaS foundation implemented** (first slice of the commercialization design). New top-level `Organization` billing tenant (in-memory + Table Storage twins + factory + `constants/plans.ts` catalog: Community/Basic/AI). Self-service `POST /api/auth/signup` creates an org (free Community plan) + owner; JWT now carries `organizationId`; `/auth/me` returns org + entitlements. New `/api/organizations/current` management routes (get/update plan + module toggles, list/create users) with `owner`/`admin` RBAC (`requireOwner` added). Feature gating via `requireFeature` middleware + `ENABLE_ENTITLEMENTS` flag (default off → backward compatible; the 525 existing tests untouched), applied to checkins/events (signInEnabled), truck-checks (truckCheckEnabled), reports (reportsEnabled). Owners can **disable the sign-in book for maintenance-only brigades** and AI is gated off below the AI plan (`clampEntitlements` prevents exceeding the plan ceiling). Frontend: `SignupPage` (`/signup`), `OrganizationPage` (`/admin/organization`), `AuthContext` extended with org/entitlements + `hasFeature`, and `FeatureRoute` guards on the gated routes. 12 new backend + 6 new frontend tests; all suites + coverage + build green. **Not yet wired:** live Stripe billing (entitlements are admin-set; Stripe Checkout/webhooks are the next slice), device accounts, and member logins — all per `docs/SAAS_COMMERCIALIZATION_DESIGN.md`.
 
-### Prioritised next steps (as of June 22, 2026)
+### Prioritised next steps (as of June 23, 2026)
 
 These are the highest-leverage items to act on next, in order. Read each track section above for full detail; this is the executive summary for picking up where we left off.
 
@@ -2899,6 +2905,7 @@ curl -H "Origin: https://malicious-site.com" \
 | 4.10 | Jun 2026 | A1 inc 2 (appliance equipment) | `ApplianceEquipment` per-truck inventory end-to-end (type, in-memory DB + Table Storage twin + factory, admin-gated CRUD `…/appliances/:id/equipment` + `…/equipment/:id`), with optional `zoneId`, `equipmentCode` slug, and an `active` retire flag (`?includeInactive`). Added a reusable mock-`TableClient` test harness covering both appliance Table twins (~8% → ~92%). 17 new tests; `api_register.json` → v1.11.0. |
 | 4.11 | Jun 2026 | A1 inc 3 (checklist links) | `ChecklistItem` gained the zone/equipment link fields (`zoneId`, `equipmentId`, `expectedResponseType`, `unit`, `promptHint`) — additive/optional, round-tripping through both the per-appliance custom overlay and `VehicleType` standard items with no persistence changes (items are spread + stored as JSON). The bridge that lets a checklist item reference a physical zone/equipment piece. 2 round-trip tests; 733 pass. |
 | 4.12 | Jun 2026 | A1 inc 4 (appliance agent context) | `Appliance` gained `variant`, `inServiceDate`, `quirksNotes` (free-text brigade knowledge for the agent), wired through `extractApplianceDetails` + `ApplianceDetails` + create/update in both DB twins (in-memory + Table Storage columns). 3 round-trip tests; 736 pass. |
+| 4.13 | Jun 2026 | A1 inc 5 (zone-vocabulary seed) | `backend/src/constants/zoneVocabulary.ts` — code-level taxonomy mapping `VehicleType.code` → `ZoneSpec[]` walk-around sequences for Cat 1 tanker / heavy tanker / pumper / bulk water tender / rescue tender / command-support (NSW RFS classes). Zones auto-seed on `POST /appliances` when a `vehicleTypeId` is supplied (non-fatal catch). New admin endpoint `POST /appliances/:id/seed-zones` with idempotent default + `?replace=true`. 18 new tests; 754 pass, all coverage gates green. |
 
 ---
 

--- a/docs/api_register.json
+++ b/docs/api_register.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lastUpdated": "2026-06-23",
   "description": "Machine-readable registry of all REST API endpoints and WebSocket events for the RFS Station Manager\n\nAll API endpoints are protected with rate limiting (≈1,000 requests per hour per IP by default (≈84 per 5-minute window), configurable via RATE_LIMIT_API_MAX environment variable).\n\nMulti-Station Support: All endpoints support optional X-Station-Id header or stationId query parameter for station-based data filtering. Defaults to 'default-station' if not provided.\n\nAuthentication: When REQUIRE_AUTH=true, many endpoints require JWT authentication via Authorization: Bearer <token> header. See individual endpoint documentation for authentication requirements.",
   "commonHeaders": {
@@ -318,6 +318,14 @@
         "description": "Delete a zone.",
         "authentication": "JWT (admin)",
         "responses": { "204": { "description": "Deleted" }, "403": { "description": "Admin required" }, "404": { "description": "Not found" } },
+        "implementation": "backend/src/routes/truckChecks.ts"
+      },
+      "POST /api/truck-checks/appliances/:id/seed-zones": {
+        "method": "POST", "path": "/api/truck-checks/appliances/:id/seed-zones",
+        "description": "Seed an appliance's zones from the starter vocabulary for its VehicleType.code (zoneVocabulary.ts). Idempotent by default — returns existing zones unchanged. Pass ?replace=true to delete and re-seed. Returns { seeded: number, zones: ApplianceZone[], message?: string }. Also triggered automatically (non-fatal) on POST /appliances when vehicleTypeId is supplied.",
+        "authentication": "JWT (admin)",
+        "queryParams": { "replace": "boolean? — if true, deletes existing zones before seeding" },
+        "responses": { "200": { "description": "{ seeded: number, zones: ApplianceZone[], message?: string }" }, "401": { "description": "Not authenticated" }, "403": { "description": "Admin required" }, "404": { "description": "Appliance not found" }, "422": { "description": "No vehicleTypeId set on appliance, or vehicle type record not found" } },
         "implementation": "backend/src/routes/truckChecks.ts"
       }
     },


### PR DESCRIPTION
## Summary

- Adds `backend/src/constants/zoneVocabulary.ts` — a code-level taxonomy mapping `VehicleType.code` to canonical walk-around `ZoneSpec[]` for standard NSW RFS appliance classes: Cat 1 tanker, heavy tanker, pumper, bulk water tender, rescue tender, and command/support
- Zones **auto-seed** on `POST /appliances` when a `vehicleTypeId` is supplied (non-fatal: if seeding fails the appliance is still created and returned)
- New admin endpoint `POST /api/truck-checks/appliances/:id/seed-zones` — idempotent by default (no-op when zones already exist), `?replace=true` deletes and re-seeds from scratch
- `api_register.json` → v1.12.0 (seed-zones endpoint documented)

## What shipped

- `backend/src/constants/zoneVocabulary.ts` (100% coverage): `ZoneSpec` type, `ZONE_VOCABULARY` record, `getStarterZones(code)` helper
- `backend/src/routes/truckChecks.ts`: import `getStarterZones`, auto-seed block in `POST /appliances`, new `POST /appliances/:id/seed-zones` route
- `backend/src/__tests__/applianceZoneSeed.test.ts`: 18 tests covering vocabulary unit tests (known codes, aliases, empty-array for unknown, ascending order, unique zoneCode per layout), auto-seed on create, seed-zones 401/404/422, idempotency, replace=true, unknown vehicle type code

## Test plan

- [ ] All 18 new tests pass (`npx jest applianceZoneSeed`)
- [ ] Full suite: 754 pass, all four coverage gates green (stmts 75.26% ≥73%, branches 66.49% ≥64%, functions 79.3% ≥75%, lines 75.98% ≥73%)
- [ ] TypeScript: `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_