### PR TITLE
feat(truck-check): zones & equipment admin authoring UI (A1 inc 6)

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -311,7 +311,14 @@ Status legend: ⬜ planned · 🟡 partial/in-progress · 🔵 needs a decision 
   `vehicleTypeId` is supplied (non-fatal catch if seed fails). New admin endpoint
   `POST /appliances/:id/seed-zones` supports explicit/idempotent seeding and
   `?replace=true` re-seed. 18 new tests (754 pass); all coverage gates green.
-  *Remaining:* admin authoring UI (the first user-facing surface). Ships standalone value (no AI).
+  *Increment 6 done 2026-06-28:* `ApplianceZonesModal` — two-tab admin authoring UI (Walk-around
+  Zones + Equipment) wired into the Vehicle Management card via a purple "Zones" button.
+  Zones tab: seed-from-vehicle-type (with `?replace=true` re-seed), ordered zone list, inline
+  edit, add form. Equipment tab: active/retired inventory, retire/restore, inline edit, zone picker,
+  add form. 11 new Vitest tests; 464 frontend tests pass. `ApplianceZoneSide`, `ApplianceZone`,
+  `ApplianceEquipment` types added to `frontend/src/types/index.ts`; 9 API methods added to
+  `frontend/src/services/api.ts`. A1 data-model track is now **feature-complete** (all 6 increments
+  shipped); next is A3 (voice agent) once D3 streaming-voice WS contract is resolved.
 - **A3 — Phase 2: voice agent (cloud)** ⬜ — PWA voice mode → agent tool-use loop
   (`get_appliance_context`/`record_result`/`flag_issue`/`next_unchecked_in_zone`/
   `complete_run`) → `CheckRun` + `AgentSession`/`AgentTurn` transcript; read-back/confirm;
@@ -466,7 +473,7 @@ is retained in the model but **unused/unenforced** (devices dropped from pricing
 - 2026-06-07: **Infrastructure-as-Code introduced (Issue #513).** Added `infra/` (Bicep) — the project's first IaC. Codifies the Table Storage data tier and provides a **dual-host comparison** (Linux B1 always-warm vs Azure Container Apps scale-to-zero) running the current Socket.io app unchanged, side-by-side with prod (prod untouched). Includes a multi-stage `Dockerfile`, a manual `infra-deploy.yml` workflow, and `infra/README.md`. **Critical finding:** the GitHub→Azure OIDC app registration was deleted from the tenant, silently breaking the last several `main` deploys (`AADSTS700016` at `Login to Azure`) — so the v1.1 merge did not reach production. The IaC README documents the one-time OIDC bootstrap that restores prod deploys. Real-time decision: **defer SignalR**; when multi-brigade scale needs a backplane, adopt **Azure Web PubSub for Socket.IO** (keeps the code, free tier) rather than a SignalR SDK rewrite. Follow-ups to raise: Windows→Linux prod migration, App Insights daily cap, managed-identity storage auth.
 - 2026-06-08: **SaaS foundation implemented** (first slice of the commercialization design). New top-level `Organization` billing tenant (in-memory + Table Storage twins + factory + `constants/plans.ts` catalog: Community/Basic/AI). Self-service `POST /api/auth/signup` creates an org (free Community plan) + owner; JWT now carries `organizationId`; `/auth/me` returns org + entitlements. New `/api/organizations/current` management routes (get/update plan + module toggles, list/create users) with `owner`/`admin` RBAC (`requireOwner` added). Feature gating via `requireFeature` middleware + `ENABLE_ENTITLEMENTS` flag (default off → backward compatible; the 525 existing tests untouched), applied to checkins/events (signInEnabled), truck-checks (truckCheckEnabled), reports (reportsEnabled). Owners can **disable the sign-in book for maintenance-only brigades** and AI is gated off below the AI plan (`clampEntitlements` prevents exceeding the plan ceiling). Frontend: `SignupPage` (`/signup`), `OrganizationPage` (`/admin/organization`), `AuthContext` extended with org/entitlements + `hasFeature`, and `FeatureRoute` guards on the gated routes. 12 new backend + 6 new frontend tests; all suites + coverage + build green. **Not yet wired:** live Stripe billing (entitlements are admin-set; Stripe Checkout/webhooks are the next slice), device accounts, and member logins — all per `docs/SAAS_COMMERCIALIZATION_DESIGN.md`.
 
-### Prioritised next steps (as of June 23, 2026)
+### Prioritised next steps (as of June 28, 2026)
 
 These are the highest-leverage items to act on next, in order. Read each track section above for full detail; this is the executive summary for picking up where we left off.
 
@@ -2906,6 +2913,7 @@ curl -H "Origin: https://malicious-site.com" \
 | 4.11 | Jun 2026 | A1 inc 3 (checklist links) | `ChecklistItem` gained the zone/equipment link fields (`zoneId`, `equipmentId`, `expectedResponseType`, `unit`, `promptHint`) — additive/optional, round-tripping through both the per-appliance custom overlay and `VehicleType` standard items with no persistence changes (items are spread + stored as JSON). The bridge that lets a checklist item reference a physical zone/equipment piece. 2 round-trip tests; 733 pass. |
 | 4.12 | Jun 2026 | A1 inc 4 (appliance agent context) | `Appliance` gained `variant`, `inServiceDate`, `quirksNotes` (free-text brigade knowledge for the agent), wired through `extractApplianceDetails` + `ApplianceDetails` + create/update in both DB twins (in-memory + Table Storage columns). 3 round-trip tests; 736 pass. |
 | 4.13 | Jun 2026 | A1 inc 5 (zone-vocabulary seed) | `backend/src/constants/zoneVocabulary.ts` — code-level taxonomy mapping `VehicleType.code` → `ZoneSpec[]` walk-around sequences for Cat 1 tanker / heavy tanker / pumper / bulk water tender / rescue tender / command-support (NSW RFS classes). Zones auto-seed on `POST /appliances` when a `vehicleTypeId` is supplied (non-fatal catch). New admin endpoint `POST /appliances/:id/seed-zones` with idempotent default + `?replace=true`. 18 new tests; 754 pass, all coverage gates green. |
+| 4.14 | Jun 2026 | A1 inc 6 (zones & equipment UI) | `ApplianceZonesModal` two-tab admin authoring UI for per-truck zones and equipment, wired into Vehicle Management cards via a "Zones" button. Zones tab: seed-from-vehicle-type bar, ordered zone list, inline edit/delete, add form. Equipment tab: active/retired toggle, inline edit, retire/restore/delete, zone picker, add form. `ApplianceZoneSide`/`ApplianceZone`/`ApplianceEquipment` types in `frontend/src/types/index.ts`; 9 API methods in `frontend/src/services/api.ts`. 11 new Vitest tests; 464 frontend tests pass. A1 data-model track feature-complete. |
 
 ---
 

--- a/frontend/src/features/truckcheck/ApplianceZonesModal.css
+++ b/frontend/src/features/truckcheck/ApplianceZonesModal.css
@@ -1,0 +1,483 @@
+/* A1 inc 6 — Appliance zones & equipment authoring modal */
+
+.azm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem;
+  z-index: 1000;
+  overflow-y: auto;
+}
+
+.azm-modal {
+  background: var(--color-surface, #fff);
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.22);
+  width: 100%;
+  max-width: 780px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 4rem);
+  overflow: hidden;
+}
+
+/* ── Header ── */
+.azm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem 0;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  padding-bottom: 0.75rem;
+}
+
+.azm-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text, #111);
+  margin: 0;
+}
+
+.azm-vehicle-name {
+  color: var(--color-primary, #e5281b);
+}
+
+.azm-close {
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: var(--color-text-muted, #6b7280);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.azm-close:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+/* ── Tabs ── */
+.azm-tabs {
+  display: flex;
+  border-bottom: 2px solid var(--color-border, #e5e7eb);
+  padding: 0 1.5rem;
+  gap: 0.25rem;
+}
+
+.azm-tab {
+  background: none;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text-muted, #6b7280);
+  cursor: pointer;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+  min-height: 44px;
+}
+
+.azm-tab:hover {
+  color: var(--color-text, #111);
+}
+
+.azm-tab--active {
+  color: var(--color-primary, #e5281b);
+  border-bottom-color: var(--color-primary, #e5281b);
+}
+
+/* ── Body ── */
+.azm-body {
+  padding: 1.25rem 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* ── Shared helpers ── */
+.azm-loading,
+.azm-empty {
+  color: var(--color-text-muted, #6b7280);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+.azm-error {
+  color: var(--color-error, #dc2626);
+  font-size: 0.875rem;
+  margin: 0.5rem 0;
+}
+
+.azm-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-weight: 500;
+  gap: 0.2rem;
+}
+
+.azm-chip--code {
+  background: var(--color-surface-alt, #f3f4f6);
+  color: var(--color-text-muted, #6b7280);
+  font-family: ui-monospace, monospace;
+}
+
+.azm-chip--side {
+  background: var(--color-info-bg, #eff6ff);
+  color: var(--color-info, #1d4ed8);
+}
+
+.azm-chip--zone {
+  background: var(--color-success-bg, #f0fdf4);
+  color: var(--color-success, #15803d);
+}
+
+.azm-chip--retired {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+/* ── Buttons ── */
+.azm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.45rem 0.9rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  min-height: 36px;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
+}
+
+.azm-btn--primary {
+  background: var(--color-primary, #e5281b);
+  color: #fff;
+}
+
+.azm-btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-dark, #c51f12);
+}
+
+.azm-btn--secondary {
+  background: var(--color-surface-alt, #f3f4f6);
+  color: var(--color-text, #111);
+  border-color: var(--color-border, #e5e7eb);
+}
+
+.azm-btn--secondary:hover:not(:disabled) {
+  background: var(--color-surface-hover, #e9eaeb);
+}
+
+.azm-btn--danger-ghost {
+  background: none;
+  color: var(--color-error, #dc2626);
+  border-color: var(--color-error, #dc2626);
+}
+
+.azm-btn--danger-ghost:hover:not(:disabled) {
+  background: #fef2f2;
+}
+
+.azm-btn--icon {
+  padding: 0.3rem 0.5rem;
+  background: none;
+  font-size: 1rem;
+  min-width: 36px;
+  min-height: 36px;
+  border-color: transparent;
+}
+
+.azm-btn--icon:hover:not(:disabled) {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+.azm-btn--danger:hover:not(:disabled) {
+  background: #fef2f2;
+}
+
+.azm-btn--warn:hover:not(:disabled) {
+  background: #fff7ed;
+}
+
+.azm-btn--restore:hover:not(:disabled) {
+  background: #f0fdf4;
+}
+
+.azm-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ── Add form ── */
+.azm-add-form {
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  padding-top: 1rem;
+  margin-top: 1rem;
+}
+
+.azm-add-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.6rem;
+}
+
+.azm-add-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.azm-input {
+  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #111);
+  min-height: 36px;
+}
+
+.azm-input:focus {
+  outline: 2px solid var(--color-primary, #e5281b);
+  outline-offset: -1px;
+  border-color: var(--color-primary, #e5281b);
+}
+
+.azm-input--grow {
+  flex: 1;
+  min-width: 160px;
+}
+
+.azm-select {
+  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #111);
+  min-height: 36px;
+  cursor: pointer;
+}
+
+.azm-select:focus {
+  outline: 2px solid var(--color-primary, #e5281b);
+  outline-offset: -1px;
+}
+
+/* ── Seed bar ── */
+.azm-seed-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  background: var(--color-surface-alt, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+}
+
+.azm-seed-msg {
+  font-size: 0.875rem;
+  color: var(--color-success, #15803d);
+}
+
+.azm-seed-hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* ── Zone list ── */
+.azm-zone-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.azm-zone-row {
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.azm-zone-row--editing {
+  border-color: var(--color-primary, #e5281b);
+}
+
+.azm-zone-view,
+.azm-zone-edit {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.azm-zone-edit {
+  flex-wrap: wrap;
+}
+
+.azm-order-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface-alt, #f3f4f6);
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-muted, #6b7280);
+  flex-shrink: 0;
+}
+
+.azm-zone-info {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.azm-zone-name {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.azm-zone-desc {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b7280);
+  width: 100%;
+}
+
+.azm-row-actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+/* ── Equipment list ── */
+.azm-retired-toggle {
+  margin-bottom: 0.75rem;
+}
+
+.azm-toggle-label {
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #6b7280);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.azm-equip-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.azm-equip-row {
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.azm-equip-row--retired {
+  opacity: 0.65;
+}
+
+.azm-equip-row--editing {
+  border-color: var(--color-primary, #e5281b);
+}
+
+.azm-equip-view,
+.azm-equip-edit {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.azm-equip-edit {
+  flex-wrap: wrap;
+}
+
+.azm-equip-info {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.azm-equip-name {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.azm-equip-name--retired {
+  text-decoration: line-through;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.azm-equip-serial {
+  font-size: 0.78rem;
+  color: var(--color-text-muted, #6b7280);
+  font-family: ui-monospace, monospace;
+}
+
+.azm-equip-notes {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b7280);
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .azm-overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
+
+  .azm-modal {
+    border-radius: var(--radius-lg, 12px) var(--radius-lg, 12px) 0 0;
+    max-height: 92vh;
+  }
+
+  .azm-add-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .azm-zone-view,
+  .azm-equip-view {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/features/truckcheck/ApplianceZonesModal.test.tsx
+++ b/frontend/src/features/truckcheck/ApplianceZonesModal.test.tsx
@@ -152,4 +152,196 @@ describe('ApplianceZonesModal', () => {
     await waitFor(() => expect(mockApi.seedZones).toHaveBeenCalledWith('app-1', false));
     expect(await screen.findByText(/seeded 6 zones/i)).toBeInTheDocument();
   });
+
+  it('shows fallback message when seed returns 0 zones', async () => {
+    const user = userEvent.setup();
+    mockApi.seedZones.mockResolvedValue({ seeded: 0, zones: [], message: 'No vocabulary for this type.' });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: /seed from vehicle type/i }));
+    expect(await screen.findByText('No vocabulary for this type.')).toBeInTheDocument();
+  });
+
+  it('shows error message when seed fails', async () => {
+    const user = userEvent.setup();
+    mockApi.seedZones.mockRejectedValue(new Error('network'));
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: /seed from vehicle type/i }));
+    expect(await screen.findByText(/seed failed/i)).toBeInTheDocument();
+  });
+
+  it('opens inline zone edit form and cancels', async () => {
+    const user = userEvent.setup();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: 'Edit Driver Side' }));
+    expect(screen.getByLabelText('Zone name')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByLabelText('Zone name')).not.toBeInTheDocument();
+  });
+
+  it('saves zone inline edit', async () => {
+    const user = userEvent.setup();
+    mockApi.updateZone.mockResolvedValue({ ...mockZone, name: 'Rear Compartment' });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: 'Edit Driver Side' }));
+    const nameInput = screen.getByLabelText('Zone name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Rear Compartment');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockApi.updateZone).toHaveBeenCalledWith('zone-1', expect.objectContaining({ name: 'Rear Compartment' })));
+    expect(mockApi.getZones).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes a zone after confirmation', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockApi.deleteZone.mockResolvedValue(undefined);
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete Driver Side' }));
+
+    await waitFor(() => expect(mockApi.deleteZone).toHaveBeenCalledWith('zone-1'));
+    expect(mockApi.getZones).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not delete zone when confirmation is cancelled', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete Driver Side' }));
+    expect(mockApi.deleteZone).not.toHaveBeenCalled();
+  });
+
+  // ── Equipment tab ────────────────────────────────────────────────────────────
+
+  it('shows validation error when equipment add submitted with empty name', async () => {
+    const user = userEvent.setup();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => screen.getByText('Hose Reel'));
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(mockApi.createEquipment).not.toHaveBeenCalled();
+  });
+
+  it('adds equipment and refreshes', async () => {
+    const user = userEvent.setup();
+    mockApi.createEquipment.mockResolvedValue({ ...mockEquipment, id: 'equip-2', name: 'Nozzle' });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => screen.getByText('Hose Reel'));
+
+    await user.type(screen.getByLabelText('New equipment name'), 'Nozzle');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(mockApi.createEquipment).toHaveBeenCalledWith('app-1', expect.objectContaining({ name: 'Nozzle' })));
+    expect(mockApi.getEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens equipment inline edit and cancels', async () => {
+    const user = userEvent.setup();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => screen.getByText('Hose Reel'));
+
+    await user.click(screen.getByRole('button', { name: 'Edit Hose Reel' }));
+    expect(screen.getByLabelText('Equipment name')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByLabelText('Equipment name')).not.toBeInTheDocument();
+  });
+
+  it('saves equipment inline edit', async () => {
+    const user = userEvent.setup();
+    mockApi.updateEquipment.mockResolvedValue({ ...mockEquipment, name: 'Updated Reel' });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => screen.getByText('Hose Reel'));
+
+    await user.click(screen.getByRole('button', { name: 'Edit Hose Reel' }));
+    const nameInput = screen.getByLabelText('Equipment name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Updated Reel');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockApi.updateEquipment).toHaveBeenCalledWith('equip-1', expect.objectContaining({ name: 'Updated Reel' })));
+    expect(mockApi.getEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('retires active equipment after confirmation', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockApi.updateEquipment.mockResolvedValue({ ...mockEquipment, active: false });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => screen.getByText('Hose Reel'));
+
+    await user.click(screen.getByRole('button', { name: 'Retire Hose Reel' }));
+
+    await waitFor(() => expect(mockApi.updateEquipment).toHaveBeenCalledWith('equip-1', { active: false }));
+    expect(mockApi.getEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('restores retired equipment after confirmation', async () => {
+    const user = userEvent.setup();
+    const retiredEquipment: ApplianceEquipment = { ...mockEquipment, active: false };
+    mockApi.getEquipment.mockResolvedValue([retiredEquipment]);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockApi.updateEquipment.mockResolvedValue({ ...retiredEquipment, active: true });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+
+    // Need to show retired to see the item
+    const toggle = await screen.findByLabelText(/show retired/i);
+    await user.click(toggle);
+
+    await user.click(screen.getByRole('button', { name: 'Restore Hose Reel' }));
+
+    await waitFor(() => expect(mockApi.updateEquipment).toHaveBeenCalledWith('equip-1', { active: true }));
+  });
+
+  it('deletes equipment after confirmation', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockApi.deleteEquipment.mockResolvedValue(undefined);
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => screen.getByText('Hose Reel'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete Hose Reel' }));
+
+    await waitFor(() => expect(mockApi.deleteEquipment).toHaveBeenCalledWith('equip-1'));
+    expect(mockApi.getEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows error when equipment load fails', async () => {
+    mockApi.getEquipment.mockRejectedValue(new Error('network'));
+    const user = userEvent.setup();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await user.click(screen.getByRole('tab', { name: /equipment/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
 });

--- a/frontend/src/features/truckcheck/ApplianceZonesModal.test.tsx
+++ b/frontend/src/features/truckcheck/ApplianceZonesModal.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApplianceZonesModal } from './ApplianceZonesModal';
+import type { Appliance, ApplianceZone, ApplianceEquipment } from '../../types';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getZones: vi.fn(),
+    createZone: vi.fn(),
+    updateZone: vi.fn(),
+    deleteZone: vi.fn(),
+    seedZones: vi.fn(),
+    getEquipment: vi.fn(),
+    createEquipment: vi.fn(),
+    updateEquipment: vi.fn(),
+    deleteEquipment: vi.fn(),
+  },
+}));
+
+import { api } from '../../services/api';
+
+const mockApi = api as Record<string, ReturnType<typeof vi.fn>>;
+
+const mockAppliance: Appliance = {
+  id: 'app-1',
+  name: 'Tanker 1',
+  vehicleTypeId: 'vt-cat1',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const mockZone: ApplianceZone = {
+  id: 'zone-1',
+  applianceId: 'app-1',
+  name: 'Driver Side',
+  side: 'driver',
+  order: 1,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const mockEquipment: ApplianceEquipment = {
+  id: 'equip-1',
+  applianceId: 'app-1',
+  name: 'Hose Reel',
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.getZones.mockResolvedValue([mockZone]);
+  mockApi.getEquipment.mockResolvedValue([mockEquipment]);
+});
+
+describe('ApplianceZonesModal', () => {
+  it('renders vehicle name in title', async () => {
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    expect(screen.getByText('Tanker 1')).toBeInTheDocument();
+  });
+
+  it('shows zones tab by default and loads zones', async () => {
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Driver Side')).toBeInTheDocument());
+    expect(mockApi.getZones).toHaveBeenCalledWith('app-1');
+  });
+
+  it('switches to equipment tab on click', async () => {
+    const user = userEvent.setup();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+
+    const equipTab = screen.getByRole('tab', { name: /equipment/i });
+    await user.click(equipTab);
+
+    await waitFor(() => expect(screen.getByText('Hose Reel')).toBeInTheDocument());
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose on Escape key', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={onClose} />);
+
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows seed-from-vehicle-type button when vehicleTypeId present', async () => {
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    const seedBtn = await screen.findByRole('button', { name: /seed from vehicle type/i });
+    expect(seedBtn).not.toBeDisabled();
+  });
+
+  it('disables seed button when no vehicleTypeId', async () => {
+    const noTypeAppliance = { ...mockAppliance, vehicleTypeId: undefined };
+    render(<ApplianceZonesModal appliance={noTypeAppliance} onClose={vi.fn()} />);
+    const seedBtn = await screen.findByRole('button', { name: /seed from vehicle type/i });
+    expect(seedBtn).toBeDisabled();
+  });
+
+  it('shows error when zone load fails', async () => {
+    mockApi.getZones.mockRejectedValue(new Error('network'));
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+
+  it('calls createZone and refreshes on add', async () => {
+    const user = userEvent.setup();
+    mockApi.createZone.mockResolvedValue({ ...mockZone, id: 'zone-2', name: 'Rear Compartment' });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    const nameInput = screen.getByLabelText('New zone name');
+    await user.type(nameInput, 'Rear Compartment');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(mockApi.createZone).toHaveBeenCalledWith('app-1', expect.objectContaining({ name: 'Rear Compartment' })));
+    expect(mockApi.getZones).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows validation error when add zone submitted with empty name', async () => {
+    const user = userEvent.setup();
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(mockApi.createZone).not.toHaveBeenCalled();
+  });
+
+  it('calls seedZones and refreshes on seed click', async () => {
+    const user = userEvent.setup();
+    mockApi.seedZones.mockResolvedValue({ seeded: 6, zones: [] });
+
+    render(<ApplianceZonesModal appliance={mockAppliance} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Driver Side'));
+
+    const seedBtn = screen.getByRole('button', { name: /seed from vehicle type/i });
+    await user.click(seedBtn);
+
+    await waitFor(() => expect(mockApi.seedZones).toHaveBeenCalledWith('app-1', false));
+    expect(await screen.findByText(/seeded 6 zones/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/truckcheck/ApplianceZonesModal.tsx
+++ b/frontend/src/features/truckcheck/ApplianceZonesModal.tsx
@@ -1,0 +1,588 @@
+/**
+ * A1 inc 6 — Admin authoring UI for per-truck zones and equipment.
+ *
+ * Two-tab modal:
+ *  "Walk-around Zones"  — ordered spatial areas; seed from vehicle type, add, edit, delete.
+ *  "Equipment"          — per-truck inventory; add, edit, retire, restore.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../../services/api';
+import type { Appliance, ApplianceZone, ApplianceEquipment, ApplianceZoneSide } from '../../types';
+import './ApplianceZonesModal.css';
+
+interface Props {
+  appliance: Appliance;
+  onClose: () => void;
+}
+
+type Tab = 'zones' | 'equipment';
+
+const SIDES: { value: ApplianceZoneSide; label: string }[] = [
+  { value: 'driver',    label: 'Driver side' },
+  { value: 'passenger', label: 'Passenger side' },
+  { value: 'front',     label: 'Front' },
+  { value: 'rear',      label: 'Rear' },
+  { value: 'top',       label: 'Top / Roof' },
+  { value: 'interior',  label: 'Interior / Cab' },
+  { value: 'na',        label: 'N/A' },
+];
+
+function sideLabelFor(side?: ApplianceZoneSide): string {
+  return SIDES.find((s) => s.value === side)?.label ?? '';
+}
+
+// ─── Zones tab ───────────────────────────────────────────────────────────────
+
+interface ZoneFormState {
+  name: string;
+  side: ApplianceZoneSide | '';
+  description: string;
+}
+
+const EMPTY_ZONE_FORM: ZoneFormState = { name: '', side: '', description: '' };
+
+interface ZonesTabProps {
+  appliance: Appliance;
+  zones: ApplianceZone[];
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}
+
+function ZonesTab({ appliance, zones, loading, error, onRefresh }: ZonesTabProps) {
+  const [addForm, setAddForm] = useState<ZoneFormState>(EMPTY_ZONE_FORM);
+  const [addError, setAddError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<ZoneFormState>(EMPTY_ZONE_FORM);
+  const [seeding, setSeeding] = useState(false);
+  const [seedMsg, setSeedMsg] = useState<string | null>(null);
+
+  async function handleSeed(replace: boolean) {
+    setSeeding(true);
+    setSeedMsg(null);
+    try {
+      const result = await api.seedZones(appliance.id, replace);
+      setSeedMsg(
+        result.seeded > 0
+          ? `Seeded ${result.seeded} zone${result.seeded !== 1 ? 's' : ''}.`
+          : (result.message ?? 'No zones seeded.'),
+      );
+      onRefresh();
+    } catch {
+      setSeedMsg('Seed failed — check that this vehicle has a vehicle type assigned.');
+    } finally {
+      setSeeding(false);
+    }
+  }
+
+  async function handleAdd() {
+    if (!addForm.name.trim()) { setAddError('Name is required'); return; }
+    setAddError(null);
+    try {
+      await api.createZone(appliance.id, {
+        name: addForm.name.trim(),
+        side: addForm.side || undefined,
+        description: addForm.description.trim() || undefined,
+      });
+      setAddForm(EMPTY_ZONE_FORM);
+      onRefresh();
+    } catch {
+      setAddError('Failed to create zone');
+    }
+  }
+
+  function startEdit(z: ApplianceZone) {
+    setEditingId(z.id);
+    setEditForm({ name: z.name, side: z.side ?? '', description: z.description ?? '' });
+  }
+
+  async function handleSaveEdit(id: string) {
+    try {
+      await api.updateZone(id, {
+        name: editForm.name.trim() || undefined,
+        side: editForm.side || undefined,
+        description: editForm.description.trim() || undefined,
+      });
+      setEditingId(null);
+      onRefresh();
+    } catch {
+      // keep edit open on error
+    }
+  }
+
+  async function handleDelete(id: string, name: string) {
+    if (!confirm(`Delete zone "${name}"?`)) return;
+    try {
+      await api.deleteZone(id);
+      onRefresh();
+    } catch {
+      alert('Failed to delete zone');
+    }
+  }
+
+  const hasType = Boolean(appliance.vehicleTypeId);
+
+  return (
+    <div className="azm-zones-tab">
+      {/* Seed controls */}
+      <div className="azm-seed-bar">
+        <button
+          type="button"
+          className="azm-btn azm-btn--secondary"
+          onClick={() => handleSeed(false)}
+          disabled={seeding || !hasType}
+          title={hasType ? 'Seed default zones from this vehicle\'s type (skip if zones already exist)' : 'Assign a vehicle type to this vehicle first'}
+        >
+          {seeding ? 'Seeding…' : '⟳ Seed from vehicle type'}
+        </button>
+        {zones.length > 0 && hasType && (
+          <button
+            type="button"
+            className="azm-btn azm-btn--danger-ghost"
+            onClick={() => {
+              if (confirm('Replace all current zones with the vehicle type defaults?')) handleSeed(true);
+            }}
+            disabled={seeding}
+          >
+            Replace &amp; re-seed
+          </button>
+        )}
+        {seedMsg && <span className="azm-seed-msg" role="status">{seedMsg}</span>}
+        {!hasType && <span className="azm-seed-hint">Assign a vehicle type on the vehicle to enable seeding.</span>}
+      </div>
+
+      {/* Zone list */}
+      {loading && <p className="azm-loading">Loading zones…</p>}
+      {error && <p className="azm-error" role="alert">{error}</p>}
+
+      {!loading && !error && zones.length === 0 && (
+        <p className="azm-empty">No zones yet. Seed from the vehicle type above, or add them manually below.</p>
+      )}
+
+      {zones.length > 0 && (
+        <ol className="azm-zone-list" aria-label="Walk-around zones">
+          {zones.map((z) => (
+            <li key={z.id} className={`azm-zone-row${editingId === z.id ? ' azm-zone-row--editing' : ''}`}>
+              {editingId === z.id ? (
+                <div className="azm-zone-edit">
+                  <input
+                    className="azm-input"
+                    value={editForm.name}
+                    onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                    placeholder="Zone name"
+                    aria-label="Zone name"
+                  />
+                  <select
+                    className="azm-select"
+                    value={editForm.side}
+                    onChange={(e) => setEditForm({ ...editForm, side: e.target.value as ApplianceZoneSide | '' })}
+                    aria-label="Side"
+                  >
+                    <option value="">— Side —</option>
+                    {SIDES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                  </select>
+                  <input
+                    className="azm-input"
+                    value={editForm.description}
+                    onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                    placeholder="Description (optional)"
+                    aria-label="Description"
+                  />
+                  <div className="azm-row-actions">
+                    <button type="button" className="azm-btn azm-btn--primary" onClick={() => handleSaveEdit(z.id)}>Save</button>
+                    <button type="button" className="azm-btn azm-btn--secondary" onClick={() => setEditingId(null)}>Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="azm-zone-view">
+                  <span className="azm-order-badge">{z.order}</span>
+                  <div className="azm-zone-info">
+                    <span className="azm-zone-name">{z.name}</span>
+                    {z.zoneCode && <span className="azm-chip azm-chip--code">{z.zoneCode}</span>}
+                    {z.side && <span className="azm-chip azm-chip--side">{sideLabelFor(z.side)}</span>}
+                    {z.description && <span className="azm-zone-desc">{z.description}</span>}
+                  </div>
+                  <div className="azm-row-actions">
+                    <button type="button" className="azm-btn azm-btn--icon" onClick={() => startEdit(z)} aria-label={`Edit ${z.name}`}>✏️</button>
+                    <button type="button" className="azm-btn azm-btn--icon azm-btn--danger" onClick={() => handleDelete(z.id, z.name)} aria-label={`Delete ${z.name}`}>🗑️</button>
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {/* Add zone form */}
+      <div className="azm-add-form" aria-label="Add zone">
+        <h4 className="azm-add-title">Add zone</h4>
+        <div className="azm-add-row">
+          <input
+            className="azm-input azm-input--grow"
+            value={addForm.name}
+            onChange={(e) => setAddForm({ ...addForm, name: e.target.value })}
+            placeholder="Zone name *"
+            aria-label="New zone name"
+          />
+          <select
+            className="azm-select"
+            value={addForm.side}
+            onChange={(e) => setAddForm({ ...addForm, side: e.target.value as ApplianceZoneSide | '' })}
+            aria-label="Side"
+          >
+            <option value="">— Side —</option>
+            {SIDES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+          </select>
+          <input
+            className="azm-input azm-input--grow"
+            value={addForm.description}
+            onChange={(e) => setAddForm({ ...addForm, description: e.target.value })}
+            placeholder="Description (optional)"
+            aria-label="New zone description"
+          />
+          <button type="button" className="azm-btn azm-btn--primary" onClick={handleAdd}>Add</button>
+        </div>
+        {addError && <p className="azm-error" role="alert">{addError}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ─── Equipment tab ────────────────────────────────────────────────────────────
+
+interface EquipFormState {
+  name: string;
+  zoneId: string;
+  serialNumber: string;
+  notes: string;
+}
+
+const EMPTY_EQUIP_FORM: EquipFormState = { name: '', zoneId: '', serialNumber: '', notes: '' };
+
+interface EquipTabProps {
+  appliance: Appliance;
+  zones: ApplianceZone[];
+  equipment: ApplianceEquipment[];
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}
+
+function EquipTab({ appliance, zones, equipment, loading, error, onRefresh }: EquipTabProps) {
+  const [showRetired, setShowRetired] = useState(false);
+  const [addForm, setAddForm] = useState<EquipFormState>(EMPTY_EQUIP_FORM);
+  const [addError, setAddError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<EquipFormState>(EMPTY_EQUIP_FORM);
+
+  const active = equipment.filter((e) => e.active);
+  const retired = equipment.filter((e) => !e.active);
+  const visible = showRetired ? equipment : active;
+
+  function zoneNameFor(zoneId?: string) {
+    return zones.find((z) => z.id === zoneId)?.name ?? '';
+  }
+
+  async function handleAdd() {
+    if (!addForm.name.trim()) { setAddError('Name is required'); return; }
+    setAddError(null);
+    try {
+      await api.createEquipment(appliance.id, {
+        name: addForm.name.trim(),
+        zoneId: addForm.zoneId || undefined,
+        serialNumber: addForm.serialNumber.trim() || undefined,
+        notes: addForm.notes.trim() || undefined,
+      });
+      setAddForm(EMPTY_EQUIP_FORM);
+      onRefresh();
+    } catch {
+      setAddError('Failed to add equipment');
+    }
+  }
+
+  function startEdit(eq: ApplianceEquipment) {
+    setEditingId(eq.id);
+    setEditForm({
+      name: eq.name,
+      zoneId: eq.zoneId ?? '',
+      serialNumber: eq.serialNumber ?? '',
+      notes: eq.notes ?? '',
+    });
+  }
+
+  async function handleSaveEdit(id: string) {
+    try {
+      await api.updateEquipment(id, {
+        name: editForm.name.trim() || undefined,
+        zoneId: editForm.zoneId || undefined,
+        serialNumber: editForm.serialNumber.trim() || undefined,
+        notes: editForm.notes.trim() || undefined,
+      });
+      setEditingId(null);
+      onRefresh();
+    } catch {
+      // keep edit open
+    }
+  }
+
+  async function toggleActive(eq: ApplianceEquipment) {
+    const verb = eq.active ? 'retire' : 'restore';
+    if (!confirm(`${verb.charAt(0).toUpperCase() + verb.slice(1)} "${eq.name}"?`)) return;
+    try {
+      await api.updateEquipment(eq.id, { active: !eq.active });
+      onRefresh();
+    } catch {
+      alert(`Failed to ${verb} equipment`);
+    }
+  }
+
+  async function handleDelete(eq: ApplianceEquipment) {
+    if (!confirm(`Permanently delete "${eq.name}"?`)) return;
+    try {
+      await api.deleteEquipment(eq.id);
+      onRefresh();
+    } catch {
+      alert('Failed to delete equipment');
+    }
+  }
+
+  return (
+    <div className="azm-equip-tab">
+      {/* Retired toggle */}
+      {retired.length > 0 && (
+        <div className="azm-retired-toggle">
+          <label className="azm-toggle-label">
+            <input
+              type="checkbox"
+              checked={showRetired}
+              onChange={(e) => setShowRetired(e.target.checked)}
+            />
+            {' '}Show retired ({retired.length})
+          </label>
+        </div>
+      )}
+
+      {loading && <p className="azm-loading">Loading equipment…</p>}
+      {error && <p className="azm-error" role="alert">{error}</p>}
+
+      {!loading && !error && active.length === 0 && (
+        <p className="azm-empty">No equipment yet. Add items below to build the inventory for this appliance.</p>
+      )}
+
+      {visible.length > 0 && (
+        <ul className="azm-equip-list" aria-label="Equipment">
+          {visible.map((eq) => (
+            <li key={eq.id} className={`azm-equip-row${!eq.active ? ' azm-equip-row--retired' : ''}${editingId === eq.id ? ' azm-equip-row--editing' : ''}`}>
+              {editingId === eq.id ? (
+                <div className="azm-equip-edit">
+                  <input
+                    className="azm-input azm-input--grow"
+                    value={editForm.name}
+                    onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                    placeholder="Equipment name"
+                    aria-label="Equipment name"
+                  />
+                  <select
+                    className="azm-select"
+                    value={editForm.zoneId}
+                    onChange={(e) => setEditForm({ ...editForm, zoneId: e.target.value })}
+                    aria-label="Zone location"
+                  >
+                    <option value="">— No zone —</option>
+                    {zones.map((z) => <option key={z.id} value={z.id}>{z.name}</option>)}
+                  </select>
+                  <input
+                    className="azm-input"
+                    value={editForm.serialNumber}
+                    onChange={(e) => setEditForm({ ...editForm, serialNumber: e.target.value })}
+                    placeholder="Serial / asset no."
+                    aria-label="Serial number"
+                  />
+                  <input
+                    className="azm-input azm-input--grow"
+                    value={editForm.notes}
+                    onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                    placeholder="Notes"
+                    aria-label="Notes"
+                  />
+                  <div className="azm-row-actions">
+                    <button type="button" className="azm-btn azm-btn--primary" onClick={() => handleSaveEdit(eq.id)}>Save</button>
+                    <button type="button" className="azm-btn azm-btn--secondary" onClick={() => setEditingId(null)}>Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="azm-equip-view">
+                  <div className="azm-equip-info">
+                    <span className={`azm-equip-name${!eq.active ? ' azm-equip-name--retired' : ''}`}>{eq.name}</span>
+                    {eq.equipmentCode && <span className="azm-chip azm-chip--code">{eq.equipmentCode}</span>}
+                    {eq.zoneId && <span className="azm-chip azm-chip--zone">📍 {zoneNameFor(eq.zoneId)}</span>}
+                    {!eq.active && <span className="azm-chip azm-chip--retired">Retired</span>}
+                    {eq.serialNumber && <span className="azm-equip-serial">#{eq.serialNumber}</span>}
+                    {eq.notes && <span className="azm-equip-notes">{eq.notes}</span>}
+                  </div>
+                  <div className="azm-row-actions">
+                    <button type="button" className="azm-btn azm-btn--icon" onClick={() => startEdit(eq)} aria-label={`Edit ${eq.name}`}>✏️</button>
+                    <button
+                      type="button"
+                      className={`azm-btn azm-btn--icon${eq.active ? ' azm-btn--warn' : ' azm-btn--restore'}`}
+                      onClick={() => toggleActive(eq)}
+                      aria-label={eq.active ? `Retire ${eq.name}` : `Restore ${eq.name}`}
+                      title={eq.active ? 'Retire (keeps history)' : 'Restore'}
+                    >
+                      {eq.active ? '📦' : '↩️'}
+                    </button>
+                    <button type="button" className="azm-btn azm-btn--icon azm-btn--danger" onClick={() => handleDelete(eq)} aria-label={`Delete ${eq.name}`}>🗑️</button>
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Add equipment form */}
+      <div className="azm-add-form" aria-label="Add equipment">
+        <h4 className="azm-add-title">Add equipment</h4>
+        <div className="azm-add-row">
+          <input
+            className="azm-input azm-input--grow"
+            value={addForm.name}
+            onChange={(e) => setAddForm({ ...addForm, name: e.target.value })}
+            placeholder="Equipment name *"
+            aria-label="New equipment name"
+          />
+          <select
+            className="azm-select"
+            value={addForm.zoneId}
+            onChange={(e) => setAddForm({ ...addForm, zoneId: e.target.value })}
+            aria-label="Zone location"
+          >
+            <option value="">— Zone (optional) —</option>
+            {zones.map((z) => <option key={z.id} value={z.id}>{z.name}</option>)}
+          </select>
+          <input
+            className="azm-input"
+            value={addForm.serialNumber}
+            onChange={(e) => setAddForm({ ...addForm, serialNumber: e.target.value })}
+            placeholder="Serial / asset no."
+            aria-label="Serial number"
+          />
+          <button type="button" className="azm-btn azm-btn--primary" onClick={handleAdd}>Add</button>
+        </div>
+        {addError && <p className="azm-error" role="alert">{addError}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ─── Modal shell ─────────────────────────────────────────────────────────────
+
+export function ApplianceZonesModal({ appliance, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('zones');
+  const [zones, setZones] = useState<ApplianceZone[]>([]);
+  const [equipment, setEquipment] = useState<ApplianceEquipment[]>([]);
+  const [zonesLoading, setZonesLoading] = useState(true);
+  const [equipLoading, setEquipLoading] = useState(true);
+  const [zonesError, setZonesError] = useState<string | null>(null);
+  const [equipError, setEquipError] = useState<string | null>(null);
+
+  const loadZones = useCallback(async () => {
+    setZonesLoading(true);
+    setZonesError(null);
+    try {
+      setZones(await api.getZones(appliance.id));
+    } catch {
+      setZonesError('Failed to load zones');
+    } finally {
+      setZonesLoading(false);
+    }
+  }, [appliance.id]);
+
+  const loadEquipment = useCallback(async () => {
+    setEquipLoading(true);
+    setEquipError(null);
+    try {
+      setEquipment(await api.getEquipment(appliance.id, true));
+    } catch {
+      setEquipError('Failed to load equipment');
+    } finally {
+      setEquipLoading(false);
+    }
+  }, [appliance.id]);
+
+  useEffect(() => { void loadZones(); }, [loadZones]);
+  useEffect(() => { void loadEquipment(); }, [loadEquipment]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="azm-overlay"
+      role="button"
+      tabIndex={0}
+      aria-label="Close zones and equipment panel"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.target === e.currentTarget && (e.key === 'Escape' || e.key === 'Enter')) onClose(); }}
+    >
+      <div
+        className="azm-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="azm-title"
+      >
+        <div className="azm-header">
+          <h2 id="azm-title" className="azm-title">
+            Zones &amp; Equipment — <span className="azm-vehicle-name">{appliance.name}</span>
+          </h2>
+          <button type="button" className="azm-close" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        <div className="azm-tabs" role="tablist">
+          <button
+            role="tab"
+            aria-selected={tab === 'zones'}
+            className={`azm-tab${tab === 'zones' ? ' azm-tab--active' : ''}`}
+            onClick={() => setTab('zones')}
+          >
+            Walk-around Zones ({zones.length})
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === 'equipment'}
+            className={`azm-tab${tab === 'equipment' ? ' azm-tab--active' : ''}`}
+            onClick={() => setTab('equipment')}
+          >
+            Equipment ({equipment.filter((e) => e.active).length})
+          </button>
+        </div>
+
+        <div className="azm-body" role="tabpanel">
+          {tab === 'zones' && (
+            <ZonesTab
+              appliance={appliance}
+              zones={zones}
+              loading={zonesLoading}
+              error={zonesError}
+              onRefresh={loadZones}
+            />
+          )}
+          {tab === 'equipment' && (
+            <EquipTab
+              appliance={appliance}
+              zones={zones}
+              equipment={equipment}
+              loading={equipLoading}
+              error={equipError}
+              onRefresh={loadEquipment}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/truckcheck/VehicleManagement.css
+++ b/frontend/src/features/truckcheck/VehicleManagement.css
@@ -81,6 +81,7 @@
 
 .btn-edit,
 .btn-template,
+.btn-zones,
 .btn-delete {
   flex: 1;
   min-width: fit-content;
@@ -103,6 +104,11 @@
   color: white;
 }
 
+.btn-zones {
+  background: #7c3aed;
+  color: white;
+}
+
 .btn-delete {
   background: #f44336;
   color: white;
@@ -110,6 +116,7 @@
 
 .btn-edit:hover,
 .btn-template:hover,
+.btn-zones:hover,
 .btn-delete:hover {
   opacity: 0.9;
 }
@@ -409,6 +416,7 @@
 
   .btn-edit,
   .btn-template,
+  .btn-zones,
   .btn-delete {
     width: 100%;
   }

--- a/frontend/src/features/truckcheck/VehicleManagement.tsx
+++ b/frontend/src/features/truckcheck/VehicleManagement.tsx
@@ -3,6 +3,7 @@ import { api, ApiLimitError } from '../../services/api';
 import type { Appliance, ChecklistTemplate, ChecklistItem, VehicleType } from '../../types';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { ITEM_CODES, SECTIONS, resolveVocabSlug } from './checklistVocabulary';
+import { ApplianceZonesModal } from './ApplianceZonesModal';
 import './VehicleManagement.css';
 
 interface VehicleManagementProps {
@@ -12,6 +13,7 @@ interface VehicleManagementProps {
 
 export function VehicleManagement({ appliances, onUpdate }: VehicleManagementProps) {
   const [selectedVehicle, setSelectedVehicle] = useState<Appliance | null>(null);
+  const [zonesModalVehicle, setZonesModalVehicle] = useState<Appliance | null>(null);
   const [showVehicleModal, setShowVehicleModal] = useState(false);
   const [showTemplateEditor, setShowTemplateEditor] = useState(false);
   const [template, setTemplate] = useState<ChecklistTemplate | null>(null);
@@ -348,6 +350,9 @@ export function VehicleManagement({ appliances, onUpdate }: VehicleManagementPro
               <button className="btn-template" onClick={() => handleEditTemplate(vehicle)}>
                 📋 Template
               </button>
+              <button className="btn-zones" onClick={() => setZonesModalVehicle(vehicle)}>
+                🗺️ Zones
+              </button>
               <button className="btn-delete" onClick={() => handleDeleteVehicle(vehicle)}>
                 🗑️ Delete
               </button>
@@ -510,6 +515,14 @@ export function VehicleManagement({ appliances, onUpdate }: VehicleManagementPro
             </div>
           </div>
         </div>
+      )}
+
+      {/* Zones & Equipment Modal */}
+      {zonesModalVehicle && (
+        <ApplianceZonesModal
+          appliance={zonesModalVehicle}
+          onClose={() => setZonesModalVehicle(null)}
+        />
       )}
 
       {/* Template Editor Modal */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -17,7 +17,9 @@ import type {
   StationLookupResult,
   VehicleType,
   EffectiveChecklist,
-  IssueResult
+  IssueResult,
+  ApplianceZone,
+  ApplianceEquipment,
 } from '../types';
 import type { MemberAchievementSummary } from '../types/achievements';
 
@@ -682,6 +684,90 @@ class ApiService {
       headers: this.getHeaders(),
     });
     if (!response.ok) throw new Error('Failed to delete appliance');
+  }
+
+  // Appliance zones (A1)
+  async getZones(applianceId: string): Promise<ApplianceZone[]> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/appliances/${applianceId}/zones`, {
+      headers: this.getHeaders(),
+    });
+    if (!response.ok) throw new Error('Failed to fetch zones');
+    return response.json();
+  }
+
+  async createZone(applianceId: string, zone: { name: string; side?: string; description?: string; order?: number }): Promise<ApplianceZone> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/appliances/${applianceId}/zones`, {
+      method: 'POST',
+      headers: this.getHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(zone),
+    });
+    if (!response.ok) throw new Error('Failed to create zone');
+    return response.json();
+  }
+
+  async updateZone(id: string, patch: { name?: string; side?: string; description?: string; order?: number }): Promise<ApplianceZone> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/zones/${id}`, {
+      method: 'PUT',
+      headers: this.getHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(patch),
+    });
+    if (!response.ok) throw new Error('Failed to update zone');
+    return response.json();
+  }
+
+  async deleteZone(id: string): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/zones/${id}`, {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+    if (!response.ok) throw new Error('Failed to delete zone');
+  }
+
+  async seedZones(applianceId: string, replace = false): Promise<{ seeded: number; zones: ApplianceZone[]; message?: string }> {
+    const response = await fetch(
+      `${API_BASE_URL}/truck-checks/appliances/${applianceId}/seed-zones${replace ? '?replace=true' : ''}`,
+      { method: 'POST', headers: this.getHeaders() },
+    );
+    if (!response.ok) throw new Error('Failed to seed zones');
+    return response.json();
+  }
+
+  // Appliance equipment (A1)
+  async getEquipment(applianceId: string, includeInactive = false): Promise<ApplianceEquipment[]> {
+    const qs = includeInactive ? '?includeInactive=true' : '';
+    const response = await fetch(`${API_BASE_URL}/truck-checks/appliances/${applianceId}/equipment${qs}`, {
+      headers: this.getHeaders(),
+    });
+    if (!response.ok) throw new Error('Failed to fetch equipment');
+    return response.json();
+  }
+
+  async createEquipment(applianceId: string, item: { name: string; zoneId?: string; serialNumber?: string; notes?: string }): Promise<ApplianceEquipment> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/appliances/${applianceId}/equipment`, {
+      method: 'POST',
+      headers: this.getHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(item),
+    });
+    if (!response.ok) throw new Error('Failed to create equipment');
+    return response.json();
+  }
+
+  async updateEquipment(id: string, patch: { name?: string; zoneId?: string; serialNumber?: string; notes?: string; active?: boolean }): Promise<ApplianceEquipment> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/equipment/${id}`, {
+      method: 'PUT',
+      headers: this.getHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(patch),
+    });
+    if (!response.ok) throw new Error('Failed to update equipment');
+    return response.json();
+  }
+
+  async deleteEquipment(id: string): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/truck-checks/equipment/${id}`, {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+    if (!response.ok) throw new Error('Failed to delete equipment');
   }
 
   // Templates

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -163,6 +163,45 @@ export interface ChecklistItem {
   section?: string;
 }
 
+/** Physical side/face of a truck a zone sits on. */
+export type ApplianceZoneSide = 'driver' | 'passenger' | 'front' | 'rear' | 'top' | 'interior' | 'na';
+
+/**
+ * A1 — named physical area on ONE appliance, giving the agent a spatial
+ * walk-around model. Authored by admin; brigades edit freely after seeding.
+ */
+export interface ApplianceZone {
+  id: string;
+  applianceId: string;
+  stationId?: string;
+  name: string;
+  zoneCode?: string;
+  parentZoneId?: string;
+  side?: ApplianceZoneSide;
+  order: number;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * A1 — piece of equipment that lives on ONE appliance. active:false retires
+ * it without losing history.
+ */
+export interface ApplianceEquipment {
+  id: string;
+  applianceId: string;
+  stationId?: string;
+  name: string;
+  equipmentCode?: string;
+  zoneId?: string;
+  serialNumber?: string;
+  notes?: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /**
  * Status of a check result
  */


### PR DESCRIPTION
## Summary

- Adds `ApplianceZonesModal` — a two-tab admin modal for authoring per-truck **walk-around zones** and **equipment inventory**, wired into Vehicle Management cards via a purple "Zones" button.
- Completes the A1 data-model track (all 6 increments shipped); this is the first user-facing surface for the agent's spatial truck model.

## What shipped

**New files:**
- `frontend/src/features/truckcheck/ApplianceZonesModal.tsx` — two-tab modal shell + `ZonesTab` + `EquipTab` sub-components
- `frontend/src/features/truckcheck/ApplianceZonesModal.css` — full styling (responsive, CSS custom-property-based, bottom-sheet on mobile)
- `frontend/src/features/truckcheck/ApplianceZonesModal.test.tsx` — 11 Vitest tests covering render, tab switching, close, seed enable/disable, error state, add-zone validation, createZone call, seedZones call

**Modified files:**
- `frontend/src/types/index.ts` — `ApplianceZoneSide`, `ApplianceZone`, `ApplianceEquipment` types
- `frontend/src/services/api.ts` — 9 API methods: `getZones`, `createZone`, `updateZone`, `deleteZone`, `seedZones`, `getEquipment`, `createEquipment`, `updateEquipment`, `deleteEquipment`
- `frontend/src/features/truckcheck/VehicleManagement.tsx` — import + `zonesModalVehicle` state + "Zones" button + modal render
- `frontend/src/features/truckcheck/VehicleManagement.css` — `btn-zones` (purple) in shared rules + responsive block
- `docs/MASTER_PLAN.md` — inc 6 completion entry, version 4.14, next-steps date updated to Jun 28

**Zones tab features:**
- Seed-from-vehicle-type button (disabled if no `vehicleTypeId`); "Replace & re-seed" when zones already exist
- Ordered zone list with order badge, side chip, zone-code chip, description
- Inline edit (expand row) + delete per zone
- Add zone form (name required, optional side dropdown + description)

**Equipment tab features:**
- Active/retired toggle (shows count of retired items)
- Equipment list with zone-location chip, serial number, notes, retired strikethrough + chip
- Inline edit + retire/restore (keeps history) + permanent delete per item
- Add equipment form with zone picker populated from same appliance's zones

**Test results:** 464 frontend tests pass (+11), lint clean, typecheck clean.

## Test plan

- [ ] Navigate to Truck Check admin → Vehicle Management
- [ ] Confirm "Zones" button appears on each vehicle card (purple)
- [ ] Click Zones on a vehicle with a vehicle type — seed button enabled; click it to seed default zones
- [ ] Verify zone list populates with order badges, side chips
- [ ] Edit a zone inline (pencil icon), save, confirm update
- [ ] Delete a zone; confirm removal
- [ ] Add a zone manually via the add form; confirm validation fires if name is blank
- [ ] Switch to Equipment tab; add equipment; assign to a zone; confirm zone chip appears
- [ ] Retire an item (📦), toggle "Show retired" checkbox; confirm item reappears with strikethrough
- [ ] Restore a retired item (↩️)
- [ ] Close modal via ✕ button, Escape key, and overlay click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143FNz9vChm6FScLPF7h7QN)_