### PR TITLE
Fix post-deployment smoke tests for auth-gated endpoints

### DIFF
--- a/backend/src/scripts/postDeploymentTests.ts
+++ b/backend/src/scripts/postDeploymentTests.ts
@@ -359,18 +359,17 @@ async function testApiStatus(): Promise<void> {
 
 /**
  * Functional Test 3: Get Activities Endpoint
+ *
+ * `GET /api/activities` is protected by `flexibleAuth` (the data-protection
+ * gate). An unauthenticated request must be rejected with 401 — so this smoke
+ * test verifies the gate is actually live in production (a 200 here would mean
+ * activity data is exposed to anonymous callers again).
  */
 async function testGetActivities(): Promise<void> {
   const response = await makeRequest(`${APP_URL}/api/activities`);
-  
-  if (response.statusCode !== 200) {
-    throw new Error(`Expected status 200, got ${response.statusCode}`);
-  }
 
-  const data = JSON.parse(response.data);
-  
-  if (!Array.isArray(data)) {
-    throw new Error('Expected activities to be an array');
+  if (response.statusCode !== 401) {
+    throw new Error(`Expected 401 (auth-gated), got ${response.statusCode} — activity data must not be readable anonymously`);
   }
 }
 
@@ -392,18 +391,17 @@ async function testGetMembers(): Promise<void> {
 
 /**
  * Functional Test 5: Get Check-ins Endpoint
+ *
+ * `GET /api/checkins` is protected by `flexibleAuth` (the data-protection
+ * gate). An unauthenticated request must be rejected with 401 — so this smoke
+ * test verifies the gate is actually live in production (a 200 here would mean
+ * check-in data is exposed to anonymous callers again).
  */
 async function testGetCheckins(): Promise<void> {
   const response = await makeRequest(`${APP_URL}/api/checkins`);
-  
-  if (response.statusCode !== 200) {
-    throw new Error(`Expected status 200, got ${response.statusCode}`);
-  }
 
-  const data = JSON.parse(response.data);
-  
-  if (!Array.isArray(data)) {
-    throw new Error('Expected checkins to be an array');
+  if (response.statusCode !== 401) {
+    throw new Error(`Expected 401 (auth-gated), got ${response.statusCode} — check-in data must not be readable anonymously`);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixed post-deployment smoke tests to expect 401 (Unauthorized) for data endpoints that are now protected by `flexibleAuth`:
- `/api/activities`
- `/api/checkins`

These endpoints now require authentication to prevent anonymous access to sensitive station data. The smoke tests previously expected 200 status, but now correctly expect 401 for unauthenticated requests, matching the existing pattern used by the Members endpoint.

## Test Plan

- [x] Tests should now pass when deployed with `ENABLE_DATA_PROTECTION=true` (production mode)
- [x] The smoke tests correctly verify that sensitive data endpoints reject anonymous requests

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkrXuyWVf9Ep2szQf1WZqL)_