### PR TITLE
Compact mobile header and fix dropdown/contrast issues

### DIFF
--- a/frontend/src/components/AccountMenu.css
+++ b/frontend/src/components/AccountMenu.css
@@ -100,3 +100,15 @@
 .account-menu__item--danger {
   color: var(--rfs-core-red);
 }
+
+@media (max-width: 768px) {
+  .account-menu__trigger {
+    gap: 0.3rem;
+    padding: 0.3rem 0.5rem 0.3rem 0.3rem;
+    max-width: none;
+  }
+
+  .account-menu__label {
+    display: none;
+  }
+}

--- a/frontend/src/components/AdminNav.css
+++ b/frontend/src/components/AdminNav.css
@@ -57,8 +57,72 @@
   color: #fff;
 }
 
-@media (max-width: 640px) {
+.admin-nav__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Tablet - keep everything on one row, just tighten spacing */
+@media (max-width: 1024px) {
   .admin-nav {
     gap: 0.75rem;
+  }
+}
+
+/* Mobile - collapse to two compact rows instead of three: logo + actions
+   on row one, links as a single horizontally-scrollable row underneath. */
+@media (max-width: 768px) {
+  .admin-nav {
+    padding: 0.5rem 0.75rem;
+    gap: 0.5rem;
+    row-gap: 0.4rem;
+  }
+
+  .admin-nav__home {
+    order: 1;
+    font-size: 0.9rem;
+  }
+
+  .admin-nav__actions {
+    order: 2;
+    margin-left: auto;
+    gap: 0.5rem;
+  }
+
+  .admin-nav__links {
+    order: 3;
+    flex: 1 1 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    gap: 0.35rem;
+  }
+
+  .admin-nav__links::-webkit-scrollbar {
+    display: none;
+  }
+
+  .admin-nav__link {
+    padding: 0 0.65rem;
+    font-size: 0.85rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .admin-nav {
+    padding: 0.5rem 0.6rem;
+  }
+
+  .admin-nav__home-label {
+    display: none;
+  }
+
+  .admin-nav__link {
+    padding: 0 0.55rem;
+    font-size: 0.8rem;
   }
 }

--- a/frontend/src/components/AdminNav.tsx
+++ b/frontend/src/components/AdminNav.tsx
@@ -29,7 +29,7 @@ export function AdminNav() {
   return (
     <nav className="admin-nav" aria-label="Admin">
       <Link to="/" className="admin-nav__home" aria-label="Back to StationKit home">
-        <BrandMark size={20} /> StationKit
+        <BrandMark size={20} /> <span className="admin-nav__home-label">StationKit</span>
       </Link>
       <div className="admin-nav__links">
         {links.map((link) => (
@@ -42,8 +42,10 @@ export function AdminNav() {
           </NavLink>
         ))}
       </div>
-      <OrgSwitcher />
-      <AccountMenu />
+      <div className="admin-nav__actions">
+        <OrgSwitcher />
+        <AccountMenu />
+      </div>
     </nav>
   );
 }

--- a/frontend/src/components/OrgSwitcher.css
+++ b/frontend/src/components/OrgSwitcher.css
@@ -78,3 +78,15 @@
   color: var(--text-secondary);
   text-transform: capitalize;
 }
+
+@media (max-width: 768px) {
+  .org-switcher__trigger {
+    gap: 0.3rem;
+    padding: 0 0.6rem;
+    max-width: none;
+  }
+
+  .org-switcher__label {
+    display: none;
+  }
+}

--- a/frontend/src/features/admin/stations/StationDetailsView.css
+++ b/frontend/src/features/admin/stations/StationDetailsView.css
@@ -71,13 +71,13 @@
 }
 
 /* Statistics */
-.stats-grid {
+.detail-stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 1rem;
 }
 
-.stat-card {
+.detail-stat-card {
   background: var(--bg-secondary);
   border: 2px solid var(--border-color);
   border-radius: 12px;
@@ -86,21 +86,21 @@
   transition: all 0.2s;
 }
 
-.stat-card:hover {
+.detail-stat-card:hover {
   border-color: var(--rfs-core-red);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px var(--shadow-color);
 }
 
-.stat-value {
+.detail-stat-value {
   font-size: 2.5rem;
   font-weight: 700;
-  color: var(--text-error-strong);
+  color: var(--text-primary);
   line-height: 1;
   margin-bottom: 0.5rem;
 }
 
-.stat-label {
+.detail-stat-label {
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-secondary);

--- a/frontend/src/features/admin/stations/StationDetailsView.tsx
+++ b/frontend/src/features/admin/stations/StationDetailsView.tsx
@@ -204,22 +204,22 @@ export function StationDetailsView({ station, onClose, onEdit }: StationDetailsV
             {loadingStats ? (
               <div className="stats-loading">Loading statistics...</div>
             ) : statistics ? (
-              <div className="stats-grid">
-                <div className="stat-card">
-                  <div className="stat-value">{statistics.memberCount}</div>
-                  <div className="stat-label">Members</div>
+              <div className="detail-stats-grid">
+                <div className="detail-stat-card">
+                  <div className="detail-stat-value">{statistics.memberCount}</div>
+                  <div className="detail-stat-label">Members</div>
                 </div>
-                <div className="stat-card">
-                  <div className="stat-value">{statistics.eventCount}</div>
-                  <div className="stat-label">Events</div>
+                <div className="detail-stat-card">
+                  <div className="detail-stat-value">{statistics.eventCount}</div>
+                  <div className="detail-stat-label">Events</div>
                 </div>
-                <div className="stat-card">
-                  <div className="stat-value">{statistics.checkInCount}</div>
-                  <div className="stat-label">Total Check-ins</div>
+                <div className="detail-stat-card">
+                  <div className="detail-stat-value">{statistics.checkInCount}</div>
+                  <div className="detail-stat-label">Total Check-ins</div>
                 </div>
-                <div className="stat-card">
-                  <div className="stat-value">{statistics.activeCheckInCount}</div>
-                  <div className="stat-label">Active Now</div>
+                <div className="detail-stat-card">
+                  <div className="detail-stat-value">{statistics.activeCheckInCount}</div>
+                  <div className="detail-stat-label">Active Now</div>
                 </div>
               </div>
             ) : (

--- a/frontend/src/features/landing/LandingPage.css
+++ b/frontend/src/features/landing/LandingPage.css
@@ -449,6 +449,15 @@
     justify-content: flex-start;
     flex-wrap: wrap;
     gap: 0.5rem;
+    /* AccountMenu's dropdown is `position: absolute; right: 0` relative to
+       its own trigger. On this row the trigger can land anywhere (wrapped
+       icon-only buttons), so anchoring here instead keeps the dropdown
+       within the viewport's right edge instead of overflowing off-screen. */
+    position: relative;
+  }
+
+  .header-actions .account-menu {
+    position: static;
   }
 
   .header-cta {


### PR DESCRIPTION
## Summary

Fixed mobile UI issues: oversized header taking up too much vertical space, account menu dropdown rendering off-screen, and stat card contrast problems.

- **AdminNav mobile**: Collapsed to 2-row compact layout — logo + nav controls on row 1, nav links on row 2 with horizontal scrolling. Text labels hidden below 480px.
- **AccountMenu & OrgSwitcher**: Icon-only triggers on mobile (<768px) — avatar+chevron only, no text labels.
- **LandingPage dropdown fix**: Account menu dropdown now positioned relative to header-actions container, preventing off-screen overflow when trigger wraps mid-row.
- **StationDetailsView stats**: Renamed classes (stat-card → detail-stat-card) to avoid global namespace collision; changed text color from error-red to primary for regular stat values.

All changes follow the existing Header.css responsive convention (1024/768/480px breakpoints). Mobile screenshots verified. CI: all 656 frontend tests + 8 AAR tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H3NFMMoaYaUVkSgC8hP6M1)_