### PR TITLE
Fix truck check tab clipping and broken vehicle type linking CTA

### DIFF
--- a/frontend/src/features/truckcheck/AdminDashboard.css
+++ b/frontend/src/features/truckcheck/AdminDashboard.css
@@ -11,6 +11,13 @@
   display: flex;
   gap: 0.5rem;
   margin-top: 1rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tab {
@@ -26,6 +33,8 @@
   font-weight: 600;
   cursor: pointer;
   transition: background 0.2s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab:hover {
@@ -445,6 +454,11 @@
 
   .dashboard-main {
     padding: 1rem;
+  }
+
+  .tab {
+    padding: 0.65rem 1rem;
+    font-size: 0.9rem;
   }
 
   .filters-section {

--- a/frontend/src/features/truckcheck/CheckWorkflowPage.tsx
+++ b/frontend/src/features/truckcheck/CheckWorkflowPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, Fragment, type ReactNode } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
   Moon, Sun, Check, CircleCheckBig, TriangleAlert, Users, PartyPopper, Search, Camera, Upload,
@@ -13,6 +13,7 @@ import { Lightbox } from '../../components/Lightbox';
 import { Confetti } from '../../components/Confetti';
 import { PageHeader } from '../../components/PageHeader';
 import { TruckCheckShareModal } from './TruckCheckShareModal';
+import { VehicleFormModal } from './VehicleFormModal';
 import type { Appliance, ChecklistTemplate, CheckRun, CheckResult, CheckStatus, Member } from '../../types';
 import './CheckWorkflow.css';
 
@@ -22,6 +23,7 @@ export function CheckWorkflowPage() {
   const { theme, toggleTheme } = useTheme();
   const { on, off } = useSocket();
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showLinkTypeModal, setShowLinkTypeModal] = useState(false);
   const [shareStation, setShareStation] = useState<{ id: string; brigadeId: string } | null>(null);
 
   const [appliance, setAppliance] = useState<Appliance | null>(null);
@@ -425,11 +427,18 @@ export function CheckWorkflowPage() {
               standard checklist for this class of appliance) or create a custom
               checklist for it before running a check.
             </p>
-            <Link to="/truckcheck/vehicle-types" className="btn-primary">
+            <button type="button" className="btn-primary" onClick={() => setShowLinkTypeModal(true)}>
               Link a Vehicle Type
-            </Link>
+            </button>
           </div>
         </main>
+        {showLinkTypeModal && (
+          <VehicleFormModal
+            vehicle={appliance}
+            onClose={() => setShowLinkTypeModal(false)}
+            onSaved={loadData}
+          />
+        )}
       </div>
     );
   }

--- a/frontend/src/features/truckcheck/TruckCheckPage.css
+++ b/frontend/src/features/truckcheck/TruckCheckPage.css
@@ -36,9 +36,20 @@
 /* View Tabs */
 .view-tabs {
   display: flex;
-  justify-content: flex-end;
+  /* flex-start, not flex-end: with overflow-x scrolling, flex-end packs
+     content against the trailing edge and leaves the start of the row
+     unreachable by scroll in some browsers — the exact bug that clipped
+     "Add Vehicle" off-screen with no way to scroll to it on narrow phones. */
+  justify-content: flex-start;
   gap: 1rem;
   margin-bottom: 2rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.view-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tab-link {
@@ -56,6 +67,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab-link:hover {
@@ -457,6 +470,11 @@
 
   .tab-btn {
     padding: 0.75rem 1rem;
+    font-size: 0.9rem;
+  }
+
+  .tab-link {
+    padding: 0.65rem 1rem;
     font-size: 0.9rem;
   }
 }


### PR DESCRIPTION
## Summary

- Admin Dashboard tabs (`.tabs`) and Vehicle Roster tabs (`.view-tabs`/`.tab-link`) overflowed on narrow phone widths and got clipped/cut mid-word (e.g. "Chec Histo", "Follo ups"). Both rows are now horizontally scrollable with `flex-shrink: 0` + `white-space: nowrap`, matching the existing `AdminNav` pattern.
- Removed `justify-content: flex-end` on the roster tab row — combined with the overflow, it could push the first tab ("Add Vehicle") out of scroll reach entirely, which matches the reported screenshot.
- The "Link a Vehicle Type" prompt shown when starting a check on an unlinked vehicle navigated to the read-only Vehicle Types list, which has no per-vehicle assignment control — that dropdown only exists in the vehicle edit modal. The CTA now opens that same edit modal directly, scoped to the vehicle in question, and reloads the checklist after saving.

## Test plan

- [x] `npx tsc -b --noEmit` (frontend typecheck) — clean
- [x] `npm run lint` (frontend) — clean, zero warnings
- [x] `npx vitest run src/features/truckcheck/` — 88 tests passed
- [ ] Manual verification on iPad portrait/landscape (not done this session — CSS-only overflow fix, low risk, but worth a visual check before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2swkKxVADFa19ZUbYLd54

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2swkKxVADFa19ZUbYLd54)_